### PR TITLE
Swap future for six.

### DIFF
--- a/keras_retinanet/preprocessing/pascal_voc.py
+++ b/keras_retinanet/preprocessing/pascal_voc.py
@@ -19,7 +19,7 @@ from keras_retinanet.preprocessing.generator import Generator
 import cv2
 import os
 import numpy as np
-from future.utils import raise_from
+from six import raise_from
 from PIL import Image
 
 import cv2

--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,5 @@ setuptools.setup(
     maintainer='Hans Gaiser',
     maintainer_email='j.c.gaiser@delftrobotics.com',
     packages=setuptools.find_packages(),
-    install_requires=['keras', 'tensorflow-gpu', 'keras-resnet', 'future']
+    install_requires=['keras', 'tensorflow-gpu', 'keras-resnet', 'six']
 )


### PR DESCRIPTION
This PR swaps `future` for `six`. Since `keras` already uses `six`, it has to be installed for all users already anyway.