### PR TITLE
Remove unused import from examples/train_pascal.py

### DIFF
--- a/examples/train_pascal.py
+++ b/examples/train_pascal.py
@@ -21,7 +21,6 @@ import keras
 import keras.preprocessing.image
 
 import keras_retinanet.losses
-import keras_retinanet.callbacks
 from keras_retinanet.models.resnet import ResNet50RetinaNet
 from keras_retinanet.preprocessing.pascal_voc import PascalVocGenerator
 


### PR DESCRIPTION
Remove an unused import (which at this time is an empty module anyway). 