### PR TITLE
Blacklist keras 2.1.0 and 2.1.1 in utils/keras_version.

### DIFF
--- a/keras_retinanet/utils/keras_version.py
+++ b/keras_retinanet/utils/keras_version.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 import keras
 import sys
 
-minimum_keras_version = 2, 0, 9
+minimum_keras_version = 2, 1, 2
 
 
 def keras_version():
@@ -17,7 +17,7 @@ def keras_version_ok():
 def assert_keras_version():
     detected = keras.__version__
     required = '.'.join(map(str, minimum_keras_version))
-    assert(keras_version_ok()), 'You are using keras version {}. The minimum required version is {}.'.format(detected, required)
+    assert(keras_version() >= minimum_keras_version), 'You are using keras version {}. The minimum required version is {}.'.format(detected, required)
 
 
 def check_keras_version():


### PR DESCRIPTION
Alternatively we could just bump the minimum required version to 2.1.1, but then we're being unnecessarily restrictive.