### PR TITLE
Fix loss calculation when batch_size>1

### DIFF
--- a/keras_retinanet/losses.py
+++ b/keras_retinanet/losses.py
@@ -18,6 +18,7 @@ import keras
 import keras_retinanet
 
 
+
 def focal(alpha=0.25, gamma=2.0):
     def _focal(y_true, y_pred):
         # discard batches, throw all labels / classifications on one big blob
@@ -47,21 +48,66 @@ def focal(alpha=0.25, gamma=2.0):
         return cls_loss
 
     return _focal
+'''
+def focal(alpha=0.25, gamma=2.0):
+    def _focal(y_true, y_pred):
 
+        # compute the divisor: for each image in the batch, we want the number of positive anchors
+
+        # override the -1 labels, since we treat -1/0 the same way for determining the divisor
+        divisor   = keras_retinanet.backend.where(y_true < 0, keras.backend.zeros_like(y_true), y_true)
+        divisor   = keras.backend.max(divisor, axis=2)
+        divisor   = keras.backend.cast(divisor, keras.backend.floatx())
+        # compute the number of positive anchors
+        divisor   = keras.backend.sum(divisor, 1)
+        #  ensure we do not divide by 0
+        divisor   = keras.backend.maximum(1.0, divisor)
+        # pad the tensor to have shape (batch_size, 1, 1) for future division
+        divisor   = keras.backend.expand_dims(divisor, axis=1)
+        divisor   = keras.backend.expand_dims(divisor, axis=2)
+
+        labels         = y_true
+        classification = y_pred
+
+        # compute the focal loss
+        alpha_factor = keras.backend.ones_like(labels) * alpha
+        alpha_factor = keras_retinanet.backend.where(keras.backend.equal(labels, 1), alpha_factor, 1 - alpha_factor)
+        focal_weight = keras_retinanet.backend.where(keras.backend.equal(labels, 1), 1 - classification, classification)
+        focal_weight = alpha_factor * focal_weight ** gamma
+
+        cls_loss = focal_weight * keras.backend.binary_crossentropy(labels, classification)
+
+        cls_loss = cls_loss/divisor
+
+        # filter out "ignore" anchors
+        anchor_state   = keras.backend.max(labels, axis=2)  # -1 for ignore, 0 for background, 1 for object
+        indices        = keras_retinanet.backend.where(keras.backend.not_equal(anchor_state, -1))
+
+        cls_loss = keras_retinanet.backend.gather_nd(cls_loss, indices)
+
+        return keras.backend.sum(cls_loss)/keras.backend.cast(keras.backend.shape(y_true)[0], keras.backend.floatx())
+
+    return _focal
+'''
 
 def smooth_l1(sigma=3.0):
     sigma_squared = sigma ** 2
 
     def _smooth_l1(y_true, y_pred):
-        # discard batches, throw all regression / anchor states on one big blob
-        regression        = keras.backend.reshape(y_pred, (-1, 4))
-        regression_target = keras.backend.reshape(y_true[:, :, :4], (-1, 4))
-        anchor_state      = keras.backend.reshape(y_true[:, :, 4], (-1,))
 
-        # filter out "ignore" anchors
-        indices           = keras_retinanet.backend.where(keras.backend.equal(anchor_state, 1))
-        regression        = keras_retinanet.backend.gather_nd(regression, indices)
-        regression_target = keras_retinanet.backend.gather_nd(regression_target, indices)
+        # separate target and state
+        regression        = y_pred
+        regression_target = y_true[:, :, :4]
+        anchor_state      = y_true[:, :, 4]
+
+        # compute the divisor: for each image in the batch, we want the number of positive anchors
+        divisor = keras_retinanet.backend.where(keras.backend.equal(anchor_state, 1), anchor_state, keras.backend.zeros_like(anchor_state))
+        divisor   = keras.backend.sum(divisor, axis=1)
+        divisor   = keras.backend.maximum(1.0, divisor)
+
+        # pad the tensor to have shape (batch_size, 1, 1) for future division
+        divisor   = keras.backend.expand_dims(divisor, axis=1)
+        divisor   = keras.backend.expand_dims(divisor, axis=2)
 
         # compute smooth L1 loss
         # f(x) = 0.5 * (sigma * x)^2          if |x| < 1 / sigma / sigma
@@ -73,10 +119,15 @@ def smooth_l1(sigma=3.0):
             0.5 * sigma_squared * keras.backend.pow(regression_diff, 2),
             regression_diff - 0.5 / sigma_squared
         )
-        regression_loss = keras.backend.sum(regression_loss)
+        regression_loss = regression_loss /divisor
 
-        divisor         = keras.backend.maximum(keras.backend.shape(indices)[0], 1)
-        divisor         = keras.backend.cast(divisor, keras.backend.floatx())
-        return regression_loss / divisor
+        # filter out "ignore" anchors
+        indices           = keras_retinanet.backend.where(keras.backend.equal(anchor_state, 1))
+        regression_loss = keras_retinanet.backend.gather_nd(regression_loss, indices)
+
+        # divide loss by the batch size
+        regression_loss = keras.backend.sum(regression_loss) / keras.backend.cast(keras.backend.shape(y_true)[0], keras.backend.floatx())
+
+        return regression_loss
 
     return _smooth_l1

--- a/keras_retinanet/losses.py
+++ b/keras_retinanet/losses.py
@@ -90,7 +90,7 @@ def smooth_l1(sigma=3.0):
         regression_loss = regression_loss /divisor
 
         # filter out "ignore" anchors
-        indices           = keras_retinanet.backend.where(keras.backend.equal(anchor_state, 1))
+        indices         = keras_retinanet.backend.where(keras.backend.equal(anchor_state, 1))
         regression_loss = keras_retinanet.backend.gather_nd(regression_loss, indices)
 
         # divide loss by the batch size

--- a/keras_retinanet/losses.py
+++ b/keras_retinanet/losses.py
@@ -18,37 +18,6 @@ import keras
 import keras_retinanet
 
 
-
-def focal(alpha=0.25, gamma=2.0):
-    def _focal(y_true, y_pred):
-        # discard batches, throw all labels / classifications on one big blob
-        labels         = keras.backend.reshape(y_true, (-1, keras.backend.shape(y_true)[2]))
-        classification = keras.backend.reshape(y_pred, (-1, keras.backend.shape(y_pred)[2]))
-
-        # filter out "ignore" anchors
-        anchor_state   = keras.backend.max(labels, axis=1)  # -1 for ignore, 0 for background, 1 for object
-        indices        = keras_retinanet.backend.where(keras.backend.not_equal(anchor_state, -1))
-        classification = keras_retinanet.backend.gather_nd(classification, indices)
-        labels         = keras_retinanet.backend.gather_nd(labels, indices)
-        anchor_state   = keras_retinanet.backend.gather_nd(anchor_state, indices)
-
-        # select classification scores for labeled anchors
-        alpha_factor = keras.backend.ones_like(labels) * alpha
-        alpha_factor = keras_retinanet.backend.where(keras.backend.equal(labels, 1), alpha_factor, 1 - alpha_factor)
-        focal_weight = keras_retinanet.backend.where(keras.backend.equal(labels, 1), 1 - classification, classification)
-        focal_weight = alpha_factor * focal_weight ** gamma
-
-        cls_loss = focal_weight * keras.backend.binary_crossentropy(labels, classification)
-        cls_loss = keras.backend.sum(cls_loss)
-
-        # "The total focal loss of an image is computed as the sum
-        # of the focal loss over all ~100k anchors, normalized by the
-        # number of anchors assigned to a ground-truth box."
-        cls_loss = cls_loss / (keras.backend.maximum(1.0, keras.backend.sum(anchor_state)))
-        return cls_loss
-
-    return _focal
-'''
 def focal(alpha=0.25, gamma=2.0):
     def _focal(y_true, y_pred):
 
@@ -88,7 +57,6 @@ def focal(alpha=0.25, gamma=2.0):
         return keras.backend.sum(cls_loss)/keras.backend.cast(keras.backend.shape(y_true)[0], keras.backend.floatx())
 
     return _focal
-'''
 
 def smooth_l1(sigma=3.0):
     sigma_squared = sigma ** 2


### PR DESCRIPTION
This PR fixes the loss calculation when batch_size>1. For each image in the minibatch, the loss is normalised by the number of positive anchors. So for a minibatch consisting of 2 images, which have unnormalised loss L1 and L2, and number of positive anchors N1 and N2, the loss is:
```
loss = L1/N1 + L2/N2
```
The current implementation uses (incorrectly):
```
loss = (L1+L2)/(N1+N2)
```

For testing, we can verify that the loss is the same when calculated on individual images vs on a minibatch of images, like so:
```
    import numpy as np

    X, Y = train_generator.next()
    loss_total, loss_regr, loss_class = model.test_on_batch(X, Y)
    loss_total_b =[]
    loss_regr_b =[]
    loss_class_b = []

    for i in range(X.shape[0]):
        L = model.test_on_batch(X[i:i+1, ...], [Y[0][i:i+1, ...], Y[1][i:i+1,...]])
        loss_total_b.append(L[0])
        loss_regr_b.append(L[1])
        loss_class_b.append(L[2])

    np.testing.assert_almost_equal(loss_total, np.mean(loss_total_b), decimal=5)
    np.testing.assert_almost_equal(loss_regr, np.mean(loss_regr_b), decimal=5)
    np.testing.assert_almost_equal(loss_class, np.mean(loss_class_b), decimal=5)
    
    print('passed')
```
The current implementation fails:
```
AssertionError: 
Arrays are not almost equal to 5 decimals
 ACTUAL: 1.6648083
 DESIRED: 1.6746489
```
This PR fixes the issue.
