### PR TITLE
Split next() in several methods.

### DIFF
--- a/keras_retinanet/layers/_misc.py
+++ b/keras_retinanet/layers/_misc.py
@@ -83,7 +83,7 @@ class NonMaximumSuppression(keras.layers.Layer):
         classification = classification[0]
         detections     = detections[0]
 
-        scores          = keras.backend.max(classification, axis=1)
+        scores = keras.backend.max(classification, axis=1)
 
         # selecting best anchors theoretically improves speed at the cost of minor performance
         if self.top_k:

--- a/keras_retinanet/models/retinanet.py
+++ b/keras_retinanet/models/retinanet.py
@@ -207,18 +207,14 @@ def retinanet_bbox(inputs, num_classes, nms=True, name='retinanet-bbox', *args, 
     anchors        = model.outputs[0]
     regression     = model.outputs[1]
     classification = model.outputs[2]
-    if len(model.outputs) > 3:
-        other = keras.layers.Concatenate(axis=2, name='other')(model.outputs[2:])
-    else:
-        other = None
 
     # apply predicted regression to anchors
     boxes      = keras_retinanet.layers.RegressBoxes(name='boxes')([anchors, regression])
-    detections = keras.layers.Concatenate(axis=2)([boxes, classification] + ([other] if other is not None else []))
+    detections = keras.layers.Concatenate(axis=2)([boxes, classification, *model.outputs[3:]])
 
     # additionally apply non maximum suppression
     if nms:
         detections = keras_retinanet.layers.NonMaximumSuppression(name='nms')([boxes, classification, detections])
 
     # construct the model
-    return keras.models.Model(inputs=inputs, outputs=[regression, classification, detections], name=name)
+    return keras.models.Model(inputs=inputs, outputs=[*model.outputs[1:], detections], name=name)

--- a/keras_retinanet/utils/anchors.py
+++ b/keras_retinanet/utils/anchors.py
@@ -17,7 +17,7 @@ limitations under the License.
 import numpy as np
 
 
-def anchor_targets(
+def anchor_targets_bbox(
     image_shape,
     boxes,
     num_classes,


### PR DESCRIPTION
This PR splits the `next()` method from `Generator` into several methods so that they can be overridden in subclasses. This is necessary to generate targets for "other" (non-regression, non-labels) data.