### PR TITLE
A simple clarification for COCO images setup

### DIFF
--- a/examples/ResNet50RetinaNet - COCO 2017.ipynb
+++ b/examples/ResNet50RetinaNet - COCO 2017.ipynb
@@ -88,7 +88,7 @@
     "\n",
     "# create a generator for testing data\n",
     "val_generator = CocoGenerator(\n",
-    "    '/srv/datasets/COCO',\n",
+    "    '/srv/datasets/COCO',\n",  # note that the 'val2017' directory should be placed under '/srv/datasets/COCO/images/'
     "    'val2017',\n",
     "    val_image_data_generator,\n",
     "    batch_size=1,\n",


### PR DESCRIPTION
I downloaded the `val2017` images and put them under `/srv/datasets/COCO` which did not work. The problem was `cv2.imread` was returning `None` without any descriptive message. Later I realized that the library was looking for images under `/srv/datasets/COCO/images/val2017` not under `/srv/datasets/COCO/val2017`

I added a simple comment to clarify this. 