### PR TITLE
Reduce dependency on OpenCV.

### DIFF
--- a/keras_retinanet/preprocessing/coco.py
+++ b/keras_retinanet/preprocessing/coco.py
@@ -15,8 +15,8 @@ limitations under the License.
 """
 
 from keras_retinanet.preprocessing.generator import Generator
+from keras_retinanet.utils.image import read_image_bgr
 
-import cv2
 import os
 import numpy as np
 
@@ -78,9 +78,9 @@ class CocoGenerator(Generator):
         return float(image['width']) / float(image['height'])
 
     def load_image(self, image_index):
-        image = self.coco.loadImgs(self.image_ids[image_index])[0]
-        path  = os.path.join(self.data_dir, 'images', self.set_name, image['file_name'])
-        return cv2.imread(path)
+        image_info = self.coco.loadImgs(self.image_ids[image_index])[0]
+        path       = os.path.join(self.data_dir, 'images', self.set_name, image_info['file_name'])
+        return read_image_bgr(path)
 
     def load_annotations(self, image_index):
         # get ground truth annotations

--- a/keras_retinanet/preprocessing/pascal_voc.py
+++ b/keras_retinanet/preprocessing/pascal_voc.py
@@ -15,14 +15,13 @@ limitations under the License.
 """
 
 from keras_retinanet.preprocessing.generator import Generator
+from keras_retinanet.utils.image import read_image_bgr
 
-import cv2
 import os
 import numpy as np
 from six import raise_from
 from PIL import Image
 
-import cv2
 try:
     import xml.etree.cElementTree as ET
 except ImportError:
@@ -112,7 +111,7 @@ class PascalVocGenerator(Generator):
 
     def load_image(self, image_index):
         path = os.path.join(self.data_dir, 'JPEGImages', self.image_names[image_index] + self.image_extension)
-        return cv2.imread(path)
+        return read_image_bgr(path)
 
     def __parse_annotation(self, element):
         truncated = _findNode(element, 'truncated', parse=int)

--- a/keras_retinanet/utils/image.py
+++ b/keras_retinanet/utils/image.py
@@ -23,7 +23,8 @@ import PIL
 
 
 def read_image_bgr(path):
-    return np.asarray(PIL.Image.open(path))[:, :, ::-1]
+    image = np.asarray(PIL.Image.open(path).convert('RGB'))
+    return image[:, :, ::-1]
 
 
 def preprocess_image(x):
@@ -66,7 +67,7 @@ def random_transform(
         # generate box mask and randomly transform it
         mask = np.zeros_like(image, dtype=np.uint8)
         b = boxes[index, :4].astype(int)
-        cv2.rectangle(mask, (b[0], b[1]), (b[2], b[3]), (255,) * image.shape[-1], -1)
+        mask[b[1]:b[3], b[0]:b[2], :] = 255
         mask = image_data_generator.random_transform(mask, seed=seed)[..., 0]
         mask = mask.copy()  # to force contiguous arrays
 


### PR DESCRIPTION
This PR reduces the dependency on OpenCV.

Unfortunately, OpenCV is just really fast (order of 5 times faster than PIL) in resizing an image, so the dependency is kept for `cv2.resize`.