### PR TITLE
Preserve layer config

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Execution time on NVIDIA Pascal Titan X is roughly 55msec for an image of shape 
 ## Results
 
 ### MS COCO
-The MS COCO model can be downloaded [here](https://delftrobotics-my.sharepoint.com/personal/h_gaiser_fizyr_com/_layouts/15/guestaccess.aspx?docid=058cccfc5055047ad855e7f6e80625621&authkey=AVk9jMWYhYc_HF8bSh_Sxzw&expiration=2017-12-23T16%3A23%3A44.000Z&e=564924016c7a424fb552bfb3097dadda). Results using the `cocoapi` are shown below (note: according to the paper, this configuration should achieve a mAP of 0.34).
+The MS COCO model can be downloaded [here](https://delftrobotics-my.sharepoint.com/personal/h_gaiser_fizyr_com/_layouts/15/guestaccess.aspx?docid=058cccfc5055047ad855e7f6e80625621&authkey=AVk9jMWYhYc_HF8bSh_Sxzw&expiration=2017-12-23T16%3A23%3A44.000Z&e=f7f9a27ce2aa471799bbb53d35f33a78). Results using the `cocoapi` are shown below (note: according to the paper, this configuration should achieve a mAP of 0.34).
 
 ```
  Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.305

--- a/keras_retinanet/layers/_misc.py
+++ b/keras_retinanet/layers/_misc.py
@@ -60,12 +60,15 @@ class Anchors(keras.layers.Layer):
             return (input_shape[0], None, 4)
 
     def get_config(self):
-        return {
+        config = super(Anchors, self).get_config()
+        config.update({
             'size'   : self.size,
             'stride' : self.stride,
             'ratios' : self.ratios.tolist(),
             'scales' : self.scales.tolist(),
-        }
+        })
+
+        return config
 
 
 class NonMaximumSuppression(keras.layers.Layer):
@@ -101,11 +104,14 @@ class NonMaximumSuppression(keras.layers.Layer):
         return (input_shape[2][0], None, input_shape[2][2])
 
     def get_config(self):
-        return {
+        config = super(NonMaximumSuppression, self).get_config()
+        config.update({
             'nms_threshold' : self.nms_threshold,
             'top_k'         : self.top_k,
             'max_boxes'     : self.max_boxes,
-        }
+        })
+
+        return config
 
 
 class UpsampleLike(keras.layers.Layer):

--- a/keras_retinanet/models/resnet.py
+++ b/keras_retinanet/models/resnet.py
@@ -32,7 +32,7 @@ def ResNet50RetinaNet(inputs, num_classes, weights='imagenet', *args, **kwargs):
     if weights == 'imagenet':
         weights_path = keras.applications.imagenet_utils.get_file(
             'ResNet-50-model.keras.h5',
-            WEIGHTS_PATH_NO_TOP, cache_subdir='models', md5_hash='1e511c75e9ab5c16900652ad1f6044ce'
+            WEIGHTS_PATH_NO_TOP, cache_subdir='models', md5_hash='3e9f4e4f77bbe2c9bec13b53ee1c2319'
         )
     else:
         weights_path = weights


### PR DESCRIPTION
This PR fixes the `get_config` methods of the `Anchor` and `NonMaximumSuppression` layers. The superclass wasn't called, meaning some parameters such as `name` and `trainable` were not stored in saved models (and therefore not loaded either). This issue did not affect any results in the case of `keras-retinanet` (it does for [`keras-resnet`](https://github.com/broadinstitute/keras-resnet/pull/36), it should be fixed nonetheless.

This PR also updates the download link for the COCO model and updates the md5sum for the ResNet50 model.