### PR TITLE
layers.Anchors: make sure ratios and scales are numpy arrays.

### DIFF
--- a/keras_retinanet/layers/_misc.py
+++ b/keras_retinanet/layers/_misc.py
@@ -30,8 +30,12 @@ class Anchors(keras.layers.Layer):
 
         if ratios is None:
             self.ratios  = np.array([0.5, 1, 2], keras.backend.floatx()),
+        elif isinstance(ratios, list):
+            self.ratios  = np.array(ratios)
         if scales is None:
             self.scales  = np.array([2 ** 0, 2 ** (1.0 / 3.0), 2 ** (2.0 / 3.0)], keras.backend.floatx()),
+        elif isinstance(scales, list):
+            self.scales  = np.array(scales)
 
         self.num_anchors = len(ratios) * len(scales)
         self.anchors     = keras.backend.variable(keras_retinanet.utils.anchors.generate_anchors(


### PR DESCRIPTION
Should fix #106.

After loading a model, the `ratios` and  `scales` of `layer.Anchors` are lists, not numpy arrays. The `get_config` implementation calls `.tolist()` on them, which doesn't exist for lists.