### PR TITLE
Support images without annotations in the CSV generator.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,34 +22,13 @@ For training on [MS COCO](http://cocodataset.org/#home), run:
 python examples/train_coco.py <path to MS COCO>
 ```
 
-For training on a custom dataset, a CSV file can be used as a way to pass the data. To train using your CSV, run:
+For training on a custom dataset, a CSV file can be used as a way to pass the data.
+See below for more details on the format of these CSV files.
+To train using your CSV, run:
 ```
 python examples/train_csv.py <path to csv file containing annotations> <path to csv file containing classes>
 ```
 
-The expected format of each line of the annotations CSV is:
-```
-filepath,x1,y1,x2,y2,class_name
-```
-
-Images with multiple bounding boxes should use one row per bounding box. For example:
-```
-/data/imgs/img_001.jpg,837,346,981,456,cow
-/data/imgs/img_002.jpg,215,312,279,391,cat
-/data/imgs/img_002.jpg,22,5,89,84,bird
-```
-
-Note that indexing for pixel values starts at 0. The expected format of each line of the classes CSV is:
-```
-class_name,id
-```
-
-Indexing for classes starts at 0. Do not include a background class as it is implicit. For example:
-```
-cow,0
-cat,1
-bird,2
-```
 
 In general, the steps to train on your own datasets are:
 1) Create a model by calling for instance `keras_retinanet.models.ResNet50RetinaNet` and compile it. Empirically, the following compile arguments have been found to work well:
@@ -80,6 +59,57 @@ model = keras.models.load_model('/path/to/model.h5', custom_objects=custom_objec
 ```
 
 Execution time on NVIDIA Pascal Titan X is roughly 55msec for an image of shape `1000x600x3`.
+
+## CSV datasets
+The `CSVGenerator` provides an easy way to define your own datasets.
+It uses two CSV files: one file containing annotations and one file containing a class name to ID mapping.
+
+### Annotations format
+The CSV file with annotations should contain one annotation per line.
+Images with multiple bounding boxes should use one row per bounding box.
+Note that indexing for pixel values starts at 0.
+The expected format of each line is:
+```
+path/to/image.jpg,x1,y1,x2,y2,class_name
+```
+
+Some images may not contain any labeled objects.
+To add these images to the dataset as negative examples,
+add an annotation where `x1`, `y1`, `x2`, `y2` and `class_name` are all empty:
+```
+path/to/image.jpg,,,,,
+```
+
+A full example:
+```
+/data/imgs/img_001.jpg,837,346,981,456,cow
+/data/imgs/img_002.jpg,215,312,279,391,cat
+/data/imgs/img_002.jpg,22,5,89,84,bird
+/data/imgs/img_003.jpg,,,,,
+```
+
+This defines a dataset with 3 images.
+`img_001.jpg` contains a cow.
+`img_002.jpg` contains a cat and a bird.
+`img_003.jpg` contains no interesting objects/animals.
+
+
+### Class mapping format
+The class name to ID mapping file should contain one mapping per line.
+Each line should use the following format:
+```
+class_name,id
+```
+
+Indexing for classes starts at 0.
+Do not include a background class as it is implicit.
+
+For example:
+```
+cow,0
+cat,1
+bird,2
+```
 
 ## Results
 

--- a/keras_retinanet/preprocessing/csv_generator.py
+++ b/keras_retinanet/preprocessing/csv_generator.py
@@ -62,7 +62,15 @@ def _read_annotations(csv_reader, classes):
         try:
             img_file, x1, y1, x2, y2, class_name = row
         except ValueError:
-            raise_from(ValueError('line {}: format should be \'img_file,x1,y1,x2,y2,class_name\''.format(line)), None)
+            raise_from(ValueError('line {}: format should be \'img_file,x1,y1,x2,y2,class_name\' or \'img_file,,,,,\''.format(line)), None)
+
+        if img_file not in result:
+            result[img_file] = []
+
+        # If a row contains only an image path, it's an image without annotations.
+        if (x1, y1, x2, y2, class_name) == ('', '', '', '', ''):
+            continue
+
         x1 = _parse(x1, int, 'line {}: malformed x1: {{}}'.format(line))
         y1 = _parse(y1, int, 'line {}: malformed y1: {{}}'.format(line))
         x2 = _parse(x2, int, 'line {}: malformed x2: {{}}'.format(line))
@@ -77,9 +85,6 @@ def _read_annotations(csv_reader, classes):
         # check if the current class name is correctly present
         if class_name not in classes:
             raise ValueError('line {}: unknown class name: {}'.format(line, class_name))
-
-        if img_file not in result:
-            result[img_file] = []
 
         result[img_file].append({'x1': x1, 'x2': x2, 'y1': y1, 'y2': y2, 'class': class_name})
     return result

--- a/tests/preprocessing/test_csv_generator.py
+++ b/tests/preprocessing/test_csv_generator.py
@@ -205,3 +205,11 @@ def test_read_annotations_invalid_bb_y():
         except ValueError as e:
             assert str(e).startswith("line 0: y2 (5) must be higher than y1 (8)")
             raise
+
+
+def test_read_annotations_empty_image():
+    # Check that images without annotations are parsed.
+    assert csv_generator._read_annotations(csv_str('a.png,,,,,\nb.png,,,,,'), {'a': 1}) == {'a.png': [], 'b.png': []}
+
+    # Check that lines without annotations don't clear earlier annotations.
+    assert csv_generator._read_annotations(csv_str('a.png,0,1,2,3,a\na.png,,,,,'), {'a': 1}) == {'a.png': [annotation(0, 1,  2,  3, 'a')]}


### PR DESCRIPTION
This PR allows images without annotations in the CSV generator. They can be listed with `x1`, `y1`, `x2`, `y2` and `class_name` empty:
```
path/to/image.jpg,,,,,
```

I also considered listing just the image and no trailing commas, but at least LibreOffice adds them when saving to CSV.

Unit test and README updated. I moved the format of the CSV files to their own section because it was getting a bit long.