### PR TITLE
Use relative imports for all package code.

### DIFF
--- a/keras_retinanet/backend/__init__.py
+++ b/keras_retinanet/backend/__init__.py
@@ -1,27 +1,4 @@
 import os
 
+from .dynamic import *
 from .common import *
-
-_BACKEND = "tensorflow"
-
-if "KERAS_BACKEND" in os.environ:
-    _backend = os.environ["KERAS_BACKEND"]
-
-    backends = {
-        "cntk",
-        "tensorflow",
-        "theano"
-    }
-
-    assert _backend in backends
-
-    _BACKEND = _backend
-
-if _BACKEND == "cntk":
-    from .cntk_backend import *
-elif _BACKEND == "theano":
-    from .theano_backend import *
-elif _BACKEND == "tensorflow":
-    from .tensorflow_backend import *
-else:
-    raise ValueError("Unknown backend: " + str(_BACKEND))

--- a/keras_retinanet/backend/common.py
+++ b/keras_retinanet/backend/common.py
@@ -15,7 +15,7 @@ limitations under the License.
 """
 
 import keras.backend
-import keras_retinanet.backend
+from .dynamic import meshgrid
 
 import numpy as np
 
@@ -62,7 +62,7 @@ def shift(shape, stride, anchors):
     shift_x = (keras.backend.arange(0, shape[1], dtype=keras.backend.floatx()) + keras.backend.constant(0.5, dtype=keras.backend.floatx())) * stride
     shift_y = (keras.backend.arange(0, shape[0], dtype=keras.backend.floatx()) + keras.backend.constant(0.5, dtype=keras.backend.floatx())) * stride
 
-    shift_x, shift_y = keras_retinanet.backend.meshgrid(shift_x, shift_y)
+    shift_x, shift_y = meshgrid(shift_x, shift_y)
     shift_x = keras.backend.reshape(shift_x, [-1])
     shift_y = keras.backend.reshape(shift_y, [-1])
 

--- a/keras_retinanet/backend/dynamic.py
+++ b/keras_retinanet/backend/dynamic.py
@@ -1,0 +1,25 @@
+import os
+
+_BACKEND = "tensorflow"
+
+if "KERAS_BACKEND" in os.environ:
+    _backend = os.environ["KERAS_BACKEND"]
+
+    backends = {
+        "cntk",
+        "tensorflow",
+        "theano"
+    }
+
+    assert _backend in backends
+
+    _BACKEND = _backend
+
+if _BACKEND == "cntk":
+    from .cntk_backend import *
+elif _BACKEND == "theano":
+    from .theano_backend import *
+elif _BACKEND == "tensorflow":
+    from .tensorflow_backend import *
+else:
+    raise ValueError("Unknown backend: " + str(_BACKEND))

--- a/keras_retinanet/backend/tensorflow_backend.py
+++ b/keras_retinanet/backend/tensorflow_backend.py
@@ -16,7 +16,6 @@ limitations under the License.
 
 import tensorflow
 import keras
-import keras_retinanet.backend
 
 
 def top_k(*args, **kwargs):

--- a/keras_retinanet/callbacks/coco.py
+++ b/keras_retinanet/callbacks/coco.py
@@ -15,7 +15,7 @@ limitations under the License.
 """
 
 import keras
-from keras_retinanet.utils.coco_eval import evaluate_coco
+from ..utils.coco_eval import evaluate_coco
 
 
 class CocoEval(keras.callbacks.Callback):

--- a/keras_retinanet/models/resnet.py
+++ b/keras_retinanet/models/resnet.py
@@ -17,11 +17,11 @@ limitations under the License.
 import keras
 import keras_resnet
 import keras_resnet.models
-import keras_retinanet.models.retinanet
+from ..models import retinanet
 
 WEIGHTS_PATH_NO_TOP = 'https://github.com/fizyr/keras-models/releases/download/v0.0.1/ResNet-50-model.keras.h5'
 
-custom_objects = keras_retinanet.models.retinanet.custom_objects.copy()
+custom_objects = retinanet.custom_objects.copy()
 custom_objects.update(keras_resnet.custom_objects)
 
 
@@ -39,6 +39,6 @@ def ResNet50RetinaNet(inputs, num_classes, weights='imagenet', *args, **kwargs):
 
     resnet = keras_resnet.models.ResNet50(image, include_top=False, freeze_bn=True)
 
-    model = keras_retinanet.models.retinanet.retinanet_bbox(inputs=inputs, num_classes=num_classes, backbone=resnet, *args, **kwargs)
+    model = retinanet.retinanet_bbox(inputs=inputs, num_classes=num_classes, backbone=resnet, *args, **kwargs)
     model.load_weights(weights_path, by_name=True)
     return model

--- a/keras_retinanet/preprocessing/coco.py
+++ b/keras_retinanet/preprocessing/coco.py
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from keras_retinanet.preprocessing.generator import Generator
-from keras_retinanet.utils.image import read_image_bgr
+from ..preprocessing.generator import Generator
+from ..utils.image import read_image_bgr
 
 import os
 import numpy as np

--- a/keras_retinanet/preprocessing/generator.py
+++ b/keras_retinanet/preprocessing/generator.py
@@ -22,8 +22,8 @@ import warnings
 
 import keras
 
-from keras_retinanet.utils.image import preprocess_image, resize_image, random_transform
-from keras_retinanet.utils.anchors import anchor_targets_bbox
+from ..utils.image import preprocess_image, resize_image, random_transform
+from ..utils.anchors import anchor_targets_bbox
 
 
 class Generator(object):

--- a/keras_retinanet/preprocessing/pascal_voc.py
+++ b/keras_retinanet/preprocessing/pascal_voc.py
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from keras_retinanet.preprocessing.generator import Generator
-from keras_retinanet.utils.image import read_image_bgr
+from ..preprocessing.generator import Generator
+from ..utils.image import read_image_bgr
 
 import os
 import numpy as np

--- a/keras_retinanet/utils/coco_eval.py
+++ b/keras_retinanet/utils/coco_eval.py
@@ -16,7 +16,7 @@ limitations under the License.
 
 from __future__ import print_function
 
-from keras_retinanet.utils.image import preprocess_image, resize_image
+from ..utils.image import preprocess_image, resize_image
 
 from pycocotools.coco import COCO
 from pycocotools.cocoeval import COCOeval


### PR DESCRIPTION
Using absolute imports for other modules within the same package is bad practise. It can break in strange ways when installed packages are mixed with local versions.

This PR replaces *all* absolute imports for modules in the package with relative imports. Scripts sadly don't support relative imports, so the examples can not be fixed this way.