### PR TITLE
Pascal VOC generator image names reader fix

### DIFF
--- a/keras_retinanet/preprocessing/pascal_voc.py
+++ b/keras_retinanet/preprocessing/pascal_voc.py
@@ -81,7 +81,7 @@ class PascalVocGenerator(Generator):
         self.data_dir             = data_dir
         self.set_name             = set_name
         self.classes              = classes
-        self.image_names          = [l.strip() for l in open(os.path.join(data_dir, 'ImageSets', 'Main', set_name + '.txt')).readlines()]
+        self.image_names          = [l.strip().split(None, 1)[0] for l in open(os.path.join(data_dir, 'ImageSets', 'Main', set_name + '.txt')).readlines()]
         self.image_extension      = image_extension
         self.skip_truncated       = skip_truncated
         self.skip_difficult       = skip_difficult

--- a/keras_retinanet/preprocessing/pascal_voc.py
+++ b/keras_retinanet/preprocessing/pascal_voc.py
@@ -81,7 +81,7 @@ class PascalVocGenerator(Generator):
         self.data_dir             = data_dir
         self.set_name             = set_name
         self.classes              = classes
-        self.image_names          = [l.strip().split(None, 1)[0] for l in open(os.path.join(data_dir, 'ImageSets', 'Main', set_name + '.txt')).readlines()]
+        self.image_names          = [l.strip().split(maxsplit=1)[0] for l in open(os.path.join(data_dir, 'ImageSets', 'Main', set_name + '.txt')).readlines()]
         self.image_extension      = image_extension
         self.skip_truncated       = skip_truncated
         self.skip_difficult       = skip_difficult


### PR DESCRIPTION
The current version of the PASCAL VOC generator does not process the format correctly, more specifically the image set files containing the image names are not handled properly.

Example lines from one of the image set files files:
```
2008_000003 -1
2008_000002 -1
2008_000003 -1
2008_000007 -1
2008_000008 -1
```

Only the first part is the actual image name that needs to be processed, running the current generator against the official PASCAL VOC dataset generates the following error(s):

```
FileNotFoundError: [Errno 2] No such file or directory: '/var/dl-data/VOCdevkit/VOC2012/JPEGImages/2008_000002 -1.jpg'
```

As you can see the second part of the line, the `-1` is also being read and considered as part of the image name.

This small patch fixes this issue by splitting the string and ensuring only the actual filenames are being parsed.