### PR TITLE
Create base model for multi_gpu_model on cpu

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -41,12 +41,15 @@ def get_session():
 def create_models(num_classes, weights='imagenet', multi_gpu=0):
     # create "base" model (no NMS)
     image = keras.layers.Input((None, None, 3))
-    model = ResNet50RetinaNet(image, num_classes=num_classes, weights=weights, nms=False)
 
+    # Keras recommends initialising a multi-gpu model on the CPU to ease weight sharing, and to prevent OOM errors.
     # optionally wrap in a parallel model
     if args.multi_gpu > 1:
+        with tf.device('/cpu:0'):
+            model = ResNet50RetinaNet(image, num_classes=num_classes, weights=weights, nms=False)
         training_model = multi_gpu_model(model, gpus=args.multi_gpu)
     else:
+        model = ResNet50RetinaNet(image, num_classes=num_classes, weights=weights, nms=False)
         training_model = model
 
     # append NMS for prediction


### PR DESCRIPTION
Keras documentation for multi_gpu_model recommends creating the template
base model on the CPU to ease weight sharing, and to prevent some OOM
errors. This template will then be shared to multiple GPUs.
It is my understanding that this approach is "better"; whether this results in real-world tangible benefits is up for debate. But this should be considered best practice according to Keras.