### PR TITLE
Fixed scaling in notebook example to be applied to all bounding boxes

### DIFF
--- a/examples/ResNet50RetinaNet - COCO 2017.ipynb
+++ b/examples/ResNet50RetinaNet - COCO 2017.ipynb
@@ -152,7 +152,7 @@
     "scores = detections[0, np.arange(detections.shape[1]), 4 + predicted_labels]\n",
     "\n",
     "# correct for image scale\n",
-    "detections[:, :4] /= scale\n",
+    "detections[0, :, :4] /= scale\n",
     "\n",
     "# visualize detections\n",
     "for idx, (label, score) in enumerate(zip(predicted_labels, scores)):\n",


### PR DESCRIPTION
Fix for issue:
https://github.com/fizyr/keras-retinanet/issues/179