### PR TITLE
Correct a parameter error

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -155,7 +155,7 @@ def create_generators(args):
         else:
             validation_generator = None
     else:
-        raise ValueError('Invalid data type received: {}'.format(dataset_type))
+        raise ValueError('Invalid data type received: {}'.format(args.dataset_type))
 
     return train_generator, validation_generator
 


### PR DESCRIPTION
In the train.py:
correct the line as follow:
raise ValueError('Invalid data type received: {}'.format(dataset_type))---->
raise ValueError('Invalid data type received: {}'.format(args.dataset_type))