### PR TITLE
Relative or absolute translation

### DIFF
--- a/keras_retinanet/preprocessing/generator.py
+++ b/keras_retinanet/preprocessing/generator.py
@@ -122,7 +122,7 @@ class Generator(object):
 
         # randomly transform both image and annotations
         if self.transform_generator:
-            transform = adjust_transform_for_image(next(self.transform_generator), image)
+            transform = adjust_transform_for_image(next(self.transform_generator), image, self.transform_parameters.relative_translation)
             apply_transform(transform, image, self.transform_parameters)
 
             # Transform the bounding boxes in the annotations.

--- a/keras_retinanet/utils/image.py
+++ b/keras_retinanet/utils/image.py
@@ -50,7 +50,7 @@ def preprocess_image(x):
     return x
 
 
-def adjust_transform_for_image(transform, image):
+def adjust_transform_for_image(transform, image, relative_translation):
     """ Adjust a transformation for a specific image.
 
     The translation of the matrix will be scaled with the size of the image.
@@ -61,28 +61,33 @@ def adjust_transform_for_image(transform, image):
     # Move the origin of transformation.
     result = change_transform_origin(transform, (0.5 * width, 0.5 * height))
 
-    # Scale the translation with the image size.
-    result[0:2, 2] *= [width, height]
+    # Scale the translation with the image size if specified.
+    if relative_translation:
+        result[0:2, 2] *= [width, height]
 
     return result
 
 
 class TransformParameters:
-    """ Struct holding parameters determining how to transform images.
+    """ Struct holding parameters determining how to apply a transformation to an image.
 
     # Arguments
-        fill_mode:   Same as for keras.preprocessing.image.apply_transform
-        cval:        Same as for keras.preprocessing.image.apply_transform
-        data_format: Same as for keras.preprocessing.image.apply_transform
+        fill_mode:             Same as for keras.preprocessing.image.apply_transform
+        cval:                  Same as for keras.preprocessing.image.apply_transform
+        data_format:           Same as for keras.preprocessing.image.apply_transform
+        relative_translation:  If true (the default), interpret translation as a factor of the image size.
+                               If false, interpret it as absolute pixels.
     """
     def __init__(
         self,
-        fill_mode    = 'nearest',
-        cval         = 0,
-        data_format  = None,
+        fill_mode            = 'nearest',
+        cval                 = 0,
+        data_format          = None,
+        relative_translation = True,
     ):
-        self.fill_mode    = fill_mode
-        self.cval         = cval
+        self.fill_mode            = fill_mode
+        self.cval                 = cval
+        self.relative_translation = relative_translation
 
         if data_format is None:
             data_format = keras.backend.image_data_format()
@@ -101,9 +106,9 @@ def apply_transform(transform, image, params):
     return keras.preprocessing.image.apply_transform(
         image,
         transform,
-        channel_axis=params.channel_axis,
-        fill_mode=params.fill_mode,
-        cval=params.cval
+        channel_axis = params.channel_axis,
+        fill_mode    = params.fill_mode,
+        cval         = params.cval
     )
 
 

--- a/keras_retinanet/utils/transform.py
+++ b/keras_retinanet/utils/transform.py
@@ -205,6 +205,11 @@ def random_transform(
       * flip x (if applied)
       * flip y (if applied)
 
+    Note that by default, the data generators in `keras_retinanet.preprocessing.generators` interpret the translation
+    as factor of the image size. So an X translation of 0.1 would translate the image by 10% of it's width.
+    See `keras_retinanet.utils.image.TransformParameters` for a way to disable this behaviour and use absolute pixel
+    translation instead.
+
     # Arguments
         min_rotation:    The minimum rotation for the transform as scalar.
         max_rotation:    The maximum rotation for the transform as scalar.

--- a/keras_retinanet/utils/transform.py
+++ b/keras_retinanet/utils/transform.py
@@ -103,16 +103,16 @@ def random_translation(min, max, prng=DEFAULT_PRNG):
     return translation(_random_vector(min, max, prng))
 
 
-def shear(amount):
+def shear(angle):
     """ Construct a homogeneous 2D shear matrix.
     # Arguments
-        amount: the shear amount
+        angle: the shear angle in radians
     # Returns
         the shear matrix as 3 by 3 numpy array
     """
     return np.array([
-        [1, -np.sin(amount), 0],
-        [0,  np.cos(amount), 0],
+        [1, -np.sin(angle), 0],
+        [0,  np.cos(angle), 0],
         [0, 0, 1]
     ])
 
@@ -120,8 +120,8 @@ def shear(amount):
 def random_shear(min, max, prng=DEFAULT_PRNG):
     """ Construct a random 2D shear matrix with shear angle between -max and max.
     # Arguments
-        min:  the minumum shear factor.
-        max:  the maximum shear factor.
+        min:  the minumum shear angle in radians.
+        max:  the maximum shear angle in radians.
         prng: the pseudo-random number generator to use.
     # Returns
         a homogeneous 3 by 3 shear matrix
@@ -211,12 +211,12 @@ def random_transform(
     translation instead.
 
     # Arguments
-        min_rotation:    The minimum rotation for the transform as scalar.
-        max_rotation:    The maximum rotation for the transform as scalar.
+        min_rotation:    The minimum rotation in radians for the transform as scalar.
+        max_rotation:    The maximum rotation in radians for the transform as scalar.
         min_translation: The minimum translation for the transform as 2D column vector.
         max_translation: The maximum translation for the transform as 2D column vector.
-        min_shear:       The minimum shear for the transform as scalar.
-        max_shear:       The maximum shear for the transform as scalar.
+        min_shear:       The minimum shear angle for the transform in radians.
+        max_shear:       The maximum shear angle for the transform in radians.
         min_scaling:     The minimum scaling for the transform as 2D column vector.
         max_scaling:     The maximum scaling for the transform as 2D column vector.
         flip_x_chance:   The chance (0 to 1) that a transform will contain a flip along X direction.
@@ -233,9 +233,35 @@ def random_transform(
 
 
 def random_transform_generator(prng=None, **kwargs):
-    """ Create a random transform generator with the same arugments as `random_transform`.
+    """ Create a random transform generator.
 
     Uses a dedicated, newly created, properly seeded PRNG by default instead of the global DEFAULT_PRNG.
+
+    The transformation consists of the following operations in this order (from left to right):
+      * rotation
+      * translation
+      * shear
+      * scaling
+      * flip x (if applied)
+      * flip y (if applied)
+
+    Note that by default, the data generators in `keras_retinanet.preprocessing.generators` interpret the translation
+    as factor of the image size. So an X translation of 0.1 would translate the image by 10% of it's width.
+    See `keras_retinanet.utils.image.TransformParameters` for a way to disable this behaviour and use absolute pixel
+    translation instead.
+
+    # Arguments
+        min_rotation:    The minimum rotation in radians for the transform as scalar.
+        max_rotation:    The maximum rotation in radians for the transform as scalar.
+        min_translation: The minimum translation for the transform as 2D column vector.
+        max_translation: The maximum translation for the transform as 2D column vector.
+        min_shear:       The minimum shear angle for the transform in radians.
+        max_shear:       The maximum shear angle for the transform in radians.
+        min_scaling:     The minimum scaling for the transform as 2D column vector.
+        max_scaling:     The maximum scaling for the transform as 2D column vector.
+        flip_x_chance:   The chance (0 to 1) that a transform will contain a flip along X direction.
+        flip_y_chance:   The chance (0 to 1) that a transform will contain a flip along Y direction.
+        prng:            The pseudo-random number generator to use.
     """
 
     if prng is None:

--- a/keras_retinanet/utils/transform.py
+++ b/keras_retinanet/utils/transform.py
@@ -207,8 +207,8 @@ def random_transform(
 
     Note that by default, the data generators in `keras_retinanet.preprocessing.generators` interpret the translation
     as factor of the image size. So an X translation of 0.1 would translate the image by 10% of it's width.
-    See `keras_retinanet.utils.image.TransformParameters` for a way to disable this behaviour and use absolute pixel
-    translation instead.
+    Set `relative_translation` to `False` in the `TransformParameters` of a data generator to have it interpret
+    the translation directly as pixel distances instead.
 
     # Arguments
         min_rotation:    The minimum rotation in radians for the transform as scalar.
@@ -247,8 +247,8 @@ def random_transform_generator(prng=None, **kwargs):
 
     Note that by default, the data generators in `keras_retinanet.preprocessing.generators` interpret the translation
     as factor of the image size. So an X translation of 0.1 would translate the image by 10% of it's width.
-    See `keras_retinanet.utils.image.TransformParameters` for a way to disable this behaviour and use absolute pixel
-    translation instead.
+    Set `relative_translation` to `False` in the `TransformParameters` of a data generator to have it interpret
+    the translation directly as pixel distances instead.
 
     # Arguments
         min_rotation:    The minimum rotation in radians for the transform as scalar.


### PR DESCRIPTION
This PR allows translation to be interpreted as absolute pixels instead of a factor of the image size. Additionally, it tries to improve the documentation for `random_transform[_generator]` regarding units.

This should hopefully prevent misinterpretation of the values as in #227.