### PR TITLE
Add skip_mismatch to weight loading.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
     - '3.6'
     - '2.7'
 install:
-    - pip install keras==2.1.2
+    - pip install keras==2.1.3
     - pip install opencv-python>=3.3.0
     - pip install pillow
     - pip install tensorflow

--- a/keras_retinanet/models/resnet.py
+++ b/keras_retinanet/models/resnet.py
@@ -50,7 +50,7 @@ def download_imagenet(backbone):
     )
 
 
-def resnet_retinanet(num_classes, backbone=50, inputs=None, weights='imagenet', **kwargs):
+def resnet_retinanet(num_classes, backbone=50, inputs=None, weights='imagenet', skip_mismatch=True, **kwargs):
     allowed_backbones = [50, 101, 152]
     if backbone not in allowed_backbones:
         raise ValueError('Backbone (\'{}\') not in allowed backbones ({}).'.format(backbone, allowed_backbones))
@@ -80,33 +80,33 @@ def resnet_retinanet(num_classes, backbone=50, inputs=None, weights='imagenet', 
 
     # optionally load weights
     if weights_path:
-        model.load_weights(weights_path, by_name=True)
+        model.load_weights(weights_path, by_name=True, skip_mismatch=skip_mismatch)
 
     return model
 
 
-def resnet50_retinanet(num_classes, inputs=None, weights='imagenet', **kwargs):
-    return resnet_retinanet(num_classes=num_classes, backbone=50, inputs=inputs, weights=weights, **kwargs)
+def resnet50_retinanet(num_classes, inputs=None, weights='imagenet', skip_mismatch=True, **kwargs):
+    return resnet_retinanet(num_classes=num_classes, backbone=50, inputs=inputs, weights=weights, skip_mismatch=skip_mismatch, **kwargs)
 
 
-def resnet101_retinanet(num_classes, inputs=None, weights='imagenet', **kwargs):
-    return resnet_retinanet(num_classes=num_classes, backbone=101, inputs=inputs, weights=weights, **kwargs)
+def resnet101_retinanet(num_classes, inputs=None, weights='imagenet', skip_mismatch=True, **kwargs):
+    return resnet_retinanet(num_classes=num_classes, backbone=101, inputs=inputs, weights=weights, skip_mismatch=skip_mismatch, **kwargs)
 
 
-def resnet152_retinanet(num_classes, inputs=None, weights='imagenet', **kwargs):
-    return resnet_retinanet(num_classes=num_classes, backbone=152, inputs=inputs, weights=weights, **kwargs)
+def resnet152_retinanet(num_classes, inputs=None, weights='imagenet', skip_mismatch=True, **kwargs):
+    return resnet_retinanet(num_classes=num_classes, backbone=152, inputs=inputs, weights=weights, skip_mismatch=skip_mismatch, **kwargs)
 
 
-def ResNet50RetinaNet(inputs, num_classes, *args, **kwargs):
+def ResNet50RetinaNet(inputs, num_classes, skip_mismatch=True, **kwargs):
     warnings.warn("ResNet50RetinaNet is replaced by resnet50_retinanet and will be removed in a future release.")
-    return resnet50_retinanet(num_classes, inputs, *args, **kwargs)
+    return resnet50_retinanet(num_classes, inputs, *args, skip_mismatch=skip_mismatch, **kwargs)
 
 
-def ResNet101RetinaNet(inputs, num_classes, *args, **kwargs):
+def ResNet101RetinaNet(inputs, num_classes, skip_mismatch=True, **kwargs):
     warnings.warn("ResNet101RetinaNet is replaced by resnet101_retinanet and will be removed in a future release.")
-    return resnet101_retinanet(num_classes, inputs, *args, **kwargs)
+    return resnet101_retinanet(num_classes, inputs, *args, skip_mismatch=skip_mismatch, **kwargs)
 
 
-def ResNet152RetinaNet(inputs, num_classes, *args, **kwargs):
+def ResNet152RetinaNet(inputs, num_classes, skip_mismatch=True, **kwargs):
     warnings.warn("ResNet152RetinaNet is replaced by resnet152_retinanet and will be removed in a future release.")
-    return resnet152_retinanet(num_classes, inputs, *args, **kwargs)
+    return resnet152_retinanet(num_classes, inputs, *args, skip_mismatch=skip_mismatch, **kwargs)

--- a/keras_retinanet/utils/keras_version.py
+++ b/keras_retinanet/utils/keras_version.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 import keras
 import sys
 
-minimum_keras_version = 2, 1, 2
+minimum_keras_version = 2, 1, 3
 
 
 def keras_version():


### PR DESCRIPTION
This PR adds the `skip_mismatch` flag to weights loading. This flag requires Keras 2.1.3, so that version is also bumped. Alternatively I could change this such that it doesn't use `skip_mismatch` if Keras 2.1.2 is found, but I prefer to bump the minimum version instead.