### PR TITLE
Fixups transform generator

### DIFF
--- a/keras_retinanet/utils/image.py
+++ b/keras_retinanet/utils/image.py
@@ -58,12 +58,14 @@ def adjust_transform_for_image(transform, image, relative_translation):
     """
     height, width, channels = image.shape
 
-    # Move the origin of transformation.
-    result = change_transform_origin(transform, (0.5 * width, 0.5 * height))
+    result = transform
 
     # Scale the translation with the image size if specified.
     if relative_translation:
         result[0:2, 2] *= [width, height]
+
+    # Move the origin of transformation.
+    result = change_transform_origin(transform, (0.5 * width, 0.5 * height))
 
     return result
 

--- a/keras_retinanet/utils/transform.py
+++ b/keras_retinanet/utils/transform.py
@@ -228,7 +228,7 @@ def random_transform(
         random_translation(min_translation, max_translation, prng),
         random_shear(min_shear, max_shear, prng),
         random_scaling(min_scaling, max_scaling, prng),
-        random_flip(flip_x_chance, flip_x_chance)
+        random_flip(flip_x_chance, flip_y_chance)
     ])
 
 


### PR DESCRIPTION
This PR fixes 2 bugs in the transform generator.

1) The `flip_x_chance` argument was used for both x and y flips.
2) The order of the image translation transformation was wrong, resulting in crazy transformations and broke training.