### PR TITLE
Fix applying transforms to images.

### DIFF
--- a/keras_retinanet/bin/debug.py
+++ b/keras_retinanet/bin/debug.py
@@ -93,6 +93,7 @@ def parse_args(args):
     csv_parser.add_argument('annotations', help='Path to CSV file containing annotations for evaluation.')
     csv_parser.add_argument('classes',     help='Path to a CSV file containing class label mapping.')
 
+    parser.add_argument('-l', '--loop', help='Loop forever, even if the dataset is exhausted.', action='store_true')
     parser.add_argument('--no-resize', help='Disable image resizing.', dest='resize', action='store_false')
     parser.add_argument('--annotations', help='Show annotations on the image.', action='store_true')
     parser.add_argument('--random-transform', help='Randomly transform image and annotations.', action='store_true')
@@ -100,18 +101,7 @@ def parse_args(args):
     return parser.parse_args(args)
 
 
-def main(args=None):
-    # parse arguments
-    if args is None:
-        args = sys.argv[1:]
-    args = parse_args(args)
-
-    # create the generator
-    generator = create_generator(args)
-
-    # create the display window
-    cv2.namedWindow('Image', cv2.WINDOW_NORMAL)
-
+def run(generator, args):
     # display images, one at a time
     for i in range(generator.size()):
         # load the data
@@ -134,7 +124,27 @@ def main(args=None):
 
         cv2.imshow('Image', image)
         if cv2.waitKey() == ord('q'):
-            break
+            return False
+    return True
+
+
+def main(args=None):
+    # parse arguments
+    if args is None:
+        args = sys.argv[1:]
+    args = parse_args(args)
+
+    # create the generator
+    generator = create_generator(args)
+
+    # create the display window
+    cv2.namedWindow('Image', cv2.WINDOW_NORMAL)
+
+    if args.loop:
+        while run(generator, args):
+            pass
+    else:
+        run(generator, args)
 
 if __name__ == '__main__':
     main()

--- a/keras_retinanet/bin/debug.py
+++ b/keras_retinanet/bin/debug.py
@@ -37,14 +37,14 @@ from ..utils.visualization import draw_annotations
 def create_generator(args):
     # create random transform generator for augmenting training data
     transform_generator = random_transform_generator(
-        # min_rotation=-0.1,
-        # max_rotation=0.1,
-        # min_translation=(-0.1, -0.1),
-        # max_translation=(0.1, 0.1),
-        # min_shear=-0.1,
-        # max_shear=0.1,
-        # min_scaling=(0.9, 0.9),
-        # max_scaling=(1.1, 1.1),
+        min_rotation=-0.1,
+        max_rotation=0.1,
+        min_translation=(-0.1, -0.1),
+        max_translation=(0.1, 0.1),
+        min_shear=-0.1,
+        max_shear=0.1,
+        min_scaling=(0.9, 0.9),
+        max_scaling=(1.1, 1.1),
         flip_x_chance=0.5,
         flip_y_chance=0.5,
     )

--- a/keras_retinanet/preprocessing/generator.py
+++ b/keras_retinanet/preprocessing/generator.py
@@ -114,7 +114,7 @@ class Generator(object):
         # randomly transform both image and annotations
         if self.transform_generator:
             transform = adjust_transform_for_image(next(self.transform_generator), image, self.transform_parameters.relative_translation)
-            image     = np.swapaxes(apply_transform(transform, np.swapaxes(image, 0, 1), self.transform_parameters), 0, 1)
+            image     = apply_transform(transform, image, self.transform_parameters)
 
             # Transform the bounding boxes in the annotations.
             annotations = annotations.copy()

--- a/keras_retinanet/utils/transform.py
+++ b/keras_retinanet/utils/transform.py
@@ -183,14 +183,14 @@ def change_transform_origin(transform, center):
 
 
 def random_transform(
-    # min_rotation=0,
-    # max_rotation=0,
-    # min_translation=(0, 0),
-    # max_translation=(0, 0),
-    # min_shear=0,
-    # max_shear=0,
-    # min_scaling=(1, 1),
-    # max_scaling=(1, 1),
+    min_rotation=0,
+    max_rotation=0,
+    min_translation=(0, 0),
+    max_translation=(0, 0),
+    min_shear=0,
+    max_shear=0,
+    min_scaling=(1, 1),
+    max_scaling=(1, 1),
     flip_x_chance=0,
     flip_y_chance=0,
     prng=DEFAULT_PRNG
@@ -223,14 +223,13 @@ def random_transform(
         flip_y_chance:   The chance (0 to 1) that a transform will contain a flip along Y direction.
         prng:            The pseudo-random number generator to use.
     """
-    # return np.linalg.multi_dot([
-    #     random_rotation(min_rotation, max_rotation, prng),
-    #     random_translation(min_translation, max_translation, prng),
-    #     random_shear(min_shear, max_shear, prng),
-    #     random_scaling(min_scaling, max_scaling, prng),
-    #     random_flip(flip_x_chance, flip_y_chance, prng)
-    # ])
-    return random_flip(flip_x_chance, flip_y_chance, prng)
+    return np.linalg.multi_dot([
+        random_rotation(min_rotation, max_rotation, prng),
+        random_translation(min_translation, max_translation, prng),
+        random_shear(min_shear, max_shear, prng),
+        random_scaling(min_scaling, max_scaling, prng),
+        random_flip(flip_x_chance, flip_y_chance)
+    ])
 
 
 def random_transform_generator(prng=None, **kwargs):

--- a/keras_retinanet/utils/transform.py
+++ b/keras_retinanet/utils/transform.py
@@ -228,7 +228,7 @@ def random_transform(
         random_translation(min_translation, max_translation, prng),
         random_shear(min_shear, max_shear, prng),
         random_scaling(min_scaling, max_scaling, prng),
-        random_flip(flip_x_chance, flip_y_chance)
+        random_flip(flip_x_chance, flip_y_chance, prng)
     ])
 
 

--- a/keras_retinanet/utils/transform.py
+++ b/keras_retinanet/utils/transform.py
@@ -171,7 +171,8 @@ def random_flip(flip_x_chance, flip_y_chance, prng=DEFAULT_PRNG):
 
 
 def change_transform_origin(transform, center):
-    """ Create a new transform with the origin at a different location.
+    """ Create a new transform representing the same transformation,
+        only with the origin of the linear part changed.
     # Arguments:
         transform: the transformation matrix
         center: the new origin of the transformation
@@ -179,7 +180,7 @@ def change_transform_origin(transform, center):
         translate(center) * transform * translate(-center)
     """
     center = np.array(center)
-    return np.dot(np.dot(translation(center), transform), translation(-center))
+    return np.linalg.multi_dot([translation(center), transform, translation(-center)])
 
 
 def random_transform(

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setuptools.setup(
     maintainer='Hans Gaiser',
     maintainer_email='h.gaiser@fizyr.com',
     packages=setuptools.find_packages(),
-    install_requires=['keras', 'keras-resnet', 'six'],
+    install_requires=['keras', 'keras-resnet', 'six', 'scipy'],
     entry_points = {
         'console_scripts': [
             'retinanet-train=keras_retinanet.bin.train:main',


### PR DESCRIPTION
There were some problems with applying transforms to images:

* The first axis of an image stored as numpy array is the Y axis, not the X axis.

* The underlying transform function from scipy interprets the given matrix as a transformation from the original canvas to the transformed image. That is somewhat counter-intuitive: it causes a scaling of (3, 3) to **shrink** the image contents by a factor 3.

* There also seems to be an off-by-one error in scipy's transform function.

This PR changes the transformation before applying it to the image to make sure that `utils.image.apply_transform` behaves as expected.

The PR also adds an option to keep looping over a dataset to `debug.py`. That was quite useful for looking at random transformations.
