### PR TITLE
Make sure numpy 1.14 is installed in Travis (required by tensorflow from pypi)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
     - '3.6'
     - '2.7'
 install:
+    - pip install numpy==1.14.0
     - pip install keras==2.1.3
     - pip install opencv-python>=3.3.0
     - pip install pillow


### PR DESCRIPTION
This PR should fix travis. I would have preferred to specify `numpy>=1.14`, but pip seemed to ignore that request...