### PR TITLE
Add NOTICE with list of contributors.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,21 @@
+# Contributors
+
+This is a list of people who contributed patches to keras-retinanet.
+
+If you feel you should be listed here or if you have any other questions/comments on your listing here,
+please create an issue or pull request at https://github.com/fizyr/keras-retinanet/
+
+* Hans Gaiser <h.gaiser@fizyr.com>
+* Maarten de Vries <maarten@de-vri.es>
+* Ashley Williamson
+* Yann Henon
+* Sorin Panduru
+* Enrico Liscio <e.liscio@fizyr.com>
+* Mihai Morariu
+* Wudi Fang
+* yhenon
+* Mike Clark
+* Valeriu Lacatusu
+* mxvs
+* mwilder
+* hnsywangxin


### PR DESCRIPTION
This PR adds a text file called `NOTICE` with a list of contributors.

By calling it `NOTICE`, the Apache v2.0 license requires all redistributions to include the file somewhere. That includes binary distributions. If we feel that is a bit overkill, we could just call it `CONTRIBUTORS.md`, in which case it only has to be included with source distributions, not binary distributions. Feedback on this topic is welcome.

Also, I did not add any email addresses except for my co-workers and myself since I'm not sure if that would be appreciated (even though they're in the git log anyway). If you want your email address included, let me know and I'll update it (or send a PR later).

Note that the list is sorted by number of commits (that was the easiest from the command line).