### PR TITLE
Add visualization of anchors and anchored annotations in debug.py.

### DIFF
--- a/keras_retinanet/bin/debug.py
+++ b/keras_retinanet/bin/debug.py
@@ -20,6 +20,7 @@ import argparse
 import os
 import sys
 import cv2
+import numpy as np
 
 # Allow relative imports when being executed as script.
 if __name__ == "__main__" and __package__ is None:
@@ -31,7 +32,7 @@ if __name__ == "__main__" and __package__ is None:
 from ..preprocessing.pascal_voc import PascalVocGenerator
 from ..preprocessing.csv_generator import CSVGenerator
 from ..utils.transform import random_transform_generator
-from ..utils.visualization import draw_annotations
+from ..utils.visualization import draw_annotations, draw_boxes
 
 
 def create_generator(args):
@@ -94,7 +95,8 @@ def parse_args(args):
     csv_parser.add_argument('classes',     help='Path to a CSV file containing class label mapping.')
 
     parser.add_argument('--no-resize', help='Disable image resizing.', dest='resize', action='store_false')
-    parser.add_argument('--annotations', help='Show annotations on the image.', action='store_true')
+    parser.add_argument('--anchors', help='Show positive anchors on the image.', action='store_true')
+    parser.add_argument('--annotations', help='Show annotations on the image. Green annotations have anchors, red annotations don\'t and therefore don\'t contribute to training.', action='store_true')
     parser.add_argument('--random-transform', help='Randomly transform image and annotations.', action='store_true')
 
     return parser.parse_args(args)
@@ -125,12 +127,22 @@ def main(args=None):
         # resize the image and annotations
         if args.resize:
             image, image_scale = generator.resize_image(image)
-            if args.annotations:
-                annotations[:, :4] *= image_scale
+            annotations[:, :4] *= image_scale
+
+        # draw anchors on the image
+        if args.anchors:
+            labels, _, anchors = generator.anchor_targets(image.shape, annotations, generator.num_classes())
+            draw_boxes(image, anchors[np.max(labels, axis=1) == 1], (255, 255, 0), thickness=1)
 
         # draw annotations on the image
         if args.annotations:
-            draw_annotations(image, annotations, generator=generator)
+            # draw annotations in red
+            draw_annotations(image, annotations, color=(0, 0, 255), generator=generator)
+
+            # draw regressed anchors in green to override most red annotations
+            # result is that annotations without anchors are red, with anchors are green
+            labels, boxes, _ = generator.anchor_targets(image.shape, annotations, generator.num_classes())
+            draw_boxes(image, boxes[np.max(labels, axis=1) == 1], (0, 255, 0))
 
         cv2.imshow('Image', image)
         if cv2.waitKey() == ord('q'):

--- a/keras_retinanet/preprocessing/generator.py
+++ b/keras_retinanet/preprocessing/generator.py
@@ -22,7 +22,7 @@ import warnings
 
 import keras
 
-from ..utils.anchors import anchor_targets_bbox
+from ..utils.anchors import anchor_targets_bbox, bbox_transform
 from ..utils.image import (
     TransformParameters,
     adjust_transform_for_image,
@@ -182,14 +182,14 @@ class Generator(object):
     def anchor_targets(
         self,
         image_shape,
-        boxes,
+        annotations,
         num_classes,
         mask_shape=None,
         negative_overlap=0.4,
         positive_overlap=0.5,
         **kwargs
     ):
-        return anchor_targets_bbox(image_shape, boxes, num_classes, mask_shape, negative_overlap, positive_overlap, **kwargs)
+        return anchor_targets_bbox(image_shape, annotations, num_classes, mask_shape, negative_overlap, positive_overlap, **kwargs)
 
     def compute_targets(self, image_group, annotations_group):
         # get the max image shape
@@ -199,7 +199,9 @@ class Generator(object):
         labels_group     = [None] * self.batch_size
         regression_group = [None] * self.batch_size
         for index, (image, annotations) in enumerate(zip(image_group, annotations_group)):
-            labels_group[index], regression_group[index] = self.anchor_targets(max_shape, annotations, self.num_classes(), mask_shape=image.shape)
+            # compute regression targets
+            labels_group[index], annotations, anchors = self.anchor_targets(max_shape, annotations, self.num_classes(), mask_shape=image.shape)
+            regression_group[index] = bbox_transform(anchors, annotations)
 
             # append anchor states to regression targets (necessary for filtering 'ignore', 'positive' and 'negative' anchors)
             anchor_states           = np.max(labels_group[index], axis=1, keepdims=True)

--- a/keras_retinanet/utils/anchors.py
+++ b/keras_retinanet/utils/anchors.py
@@ -19,7 +19,7 @@ import numpy as np
 
 def anchor_targets_bbox(
     image_shape,
-    boxes,
+    annotations,
     num_classes,
     mask_shape=None,
     negative_overlap=0.4,
@@ -31,9 +31,9 @@ def anchor_targets_bbox(
     # label: 1 is positive, 0 is negative, -1 is dont care
     labels = np.ones((anchors.shape[0], num_classes)) * -1
 
-    if boxes.shape[0]:
-        # obtain indices of gt boxes with the greatest overlap
-        overlaps             = compute_overlap(anchors, boxes[:, :4])
+    if annotations.shape[0]:
+        # obtain indices of gt annotations with the greatest overlap
+        overlaps             = compute_overlap(anchors, annotations[:, :4])
         argmax_overlaps_inds = np.argmax(overlaps, axis=1)
         max_overlaps         = overlaps[np.arange(overlaps.shape[0]), argmax_overlaps_inds]
 
@@ -41,25 +41,24 @@ def anchor_targets_bbox(
         labels[max_overlaps < negative_overlap, :] = 0
 
         # compute box regression targets
-        boxes            = boxes[argmax_overlaps_inds]
-        bbox_reg_targets = bbox_transform(anchors, boxes)
+        annotations = annotations[argmax_overlaps_inds]
 
         # fg label: above threshold IOU
         positive_indices = max_overlaps >= positive_overlap
         labels[positive_indices, :] = 0
-        labels[positive_indices, boxes[positive_indices, 4].astype(int)] = 1
+        labels[positive_indices, annotations[positive_indices, 4].astype(int)] = 1
     else:
         # no annotations? then everything is background
         labels[:] = 0
-        bbox_reg_targets = np.zeros_like(anchors)
+        annotations = np.zeros_like(anchors)
 
-    # ignore boxes outside of image
+    # ignore annotations outside of image
     mask_shape         = image_shape if mask_shape is None else mask_shape
     anchors_centers    = np.vstack([(anchors[:, 0] + anchors[:, 2]) / 2, (anchors[:, 1] + anchors[:, 3]) / 2]).T
     indices            = np.logical_or(anchors_centers[:, 0] >= mask_shape[1], anchors_centers[:, 1] >= mask_shape[0])
     labels[indices, :] = -1
 
-    return labels, bbox_reg_targets
+    return labels, annotations, anchors
 
 
 def anchors_for_shape(

--- a/keras_retinanet/utils/visualization.py
+++ b/keras_retinanet/utils/visualization.py
@@ -44,36 +44,51 @@ def draw_caption(image, box, caption):
     cv2.putText(image, caption, (b[0], b[1] - 10), cv2.FONT_HERSHEY_PLAIN, 1, (255, 255, 255), 1)
 
 
+def draw_boxes(image, boxes, color, thickness=2):
+    """ Draws boxes on an image with a given color.
+
+    # Arguments
+        image     : The image to draw on.
+        boxes     : A [N, 4] matrix (x1, y1, x2, y2).
+        color     : The color of the boxes.
+        thickness : The thickness of the lines to draw boxes with.
+    """
+    for b in boxes:
+        draw_box(image, b, color, thickness=thickness)
+
+
 def draw_detections(image, detections, color=(255, 0, 0), generator=None):
     """ Draws detections in an image.
 
     # Arguments
         image      : The image to draw on.
-        detections : A np.ndarray of shape (num_detections, 4 + num_classes) to draw on the image.
+        detections : A [N, 4 + num_classes] matrix (x1, y1, x2, y2, cls_1, cls_2, ...).
         color      : The color of the boxes.
         generator  : (optional) Generator which can map label to class name.
     """
-    for d in detections:
-        draw_box(image, d, color)
+    draw_boxes(image, detections, color=color)
 
+    # draw labels
+    for d in detections:
         label   = np.argmax(d[4:])
         score   = d[4 + label]
         caption = (generator.label_to_name(label) if generator else label) + ': {0:.2f}'.format(score)
         draw_caption(image, d, caption)
 
 
-def draw_annotations(image, boxes, color=(0, 255, 0), generator=None):
+def draw_annotations(image, annotations, color=(0, 255, 0), generator=None):
     """ Draws annotations in an image.
 
     # Arguments
-        image     : The image to draw on.
-        boxes     : A np.ndarray of shape (num_annotations, 5) to draw on the image.
-        color     : The color of the boxes.
-        generator : (optional) Generator which can map label to class name.
+        image       : The image to draw on.
+        annotations : A [N, 5] matrix (x1, y1, x2, y2, label).
+        color       : The color of the boxes.
+        generator   : (optional) Generator which can map label to class name.
     """
-    for b in boxes:
-        draw_box(image, b, color)
+    draw_boxes(image, annotations, color)
 
+    # draw labels
+    for b in annotations:
         label   = b[4]
         caption = '{}'.format(generator.label_to_name(label) if generator else label)
         draw_caption(image, b, caption)

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setuptools.setup(
             'retinanet-train=keras_retinanet.bin.train:main',
             'retinanet-evaluate-coco=keras_retinanet.bin.evaluate_coco:main',
             'retinanet-evaluate=keras_retinanet.bin.evaluate:main',
+            'retinanet-debug=keras_retinanet.bin.debug:main',
         ],
     }
 )


### PR DESCRIPTION
This PR adds the ability to visualize anchors and something I named anchored annotation (lack of better term?). The latter are annotations which have anchors "pointing" to them (see the example below).

![screenshot from 2018-01-31 20-21-06](https://user-images.githubusercontent.com/716138/35642753-75443be2-06c4-11e8-943b-d433aac87c87.png)

In that image, you notice some annotations have a yellow edge around it. Those annotations have at least one anchor that is trying to regress to that annotation. The other annotations that have only a green edge have no anchor attached to it (most likely they are too small) and therefore don't contribute to the training process (even though one might expect them to be contributing when looking purely at the annotations).

This can be useful for debugging purposes.