### PR TITLE
Snapshot path existence check

### DIFF
--- a/keras_retinanet/bin/train.py
+++ b/keras_retinanet/bin/train.py
@@ -87,6 +87,8 @@ def create_callbacks(model, training_model, prediction_model, validation_generat
 
     # save the prediction model
     if args.snapshots:
+        # ensure directory created first; otherwise h5py will error after epoch.
+        os.makedirs(args.snapshot_path, exist_ok=True)
         checkpoint = keras.callbacks.ModelCheckpoint(
             os.path.join(
                 args.snapshot_path,


### PR DESCRIPTION
Creates the given snapshot path if it doesn't exist.

h5py would error out at the end of an epoch if the snapshot directory doesn't exist. Behaviour for things like Tensorboard logging are to create directories if they don't exist. As these are explicit arguments, it makes sense to have that default creation behaviour.

Let me know what you think?