### PR TITLE
Fix training without weights.

### DIFF
--- a/keras_retinanet/bin/train.py
+++ b/keras_retinanet/bin/train.py
@@ -250,8 +250,9 @@ def parse_args(args):
 
     group = parser.add_mutually_exclusive_group()
     group.add_argument('--snapshot',          help='Resume training from a snapshot.')
-    group.add_argument('--imagenet-weights',  help='Initialize the model with pretrained imagenet weights. This is the default behaviour.', action='store_true', default=True)
+    group.add_argument('--imagenet-weights',  help='Initialize the model with pretrained imagenet weights. This is the default behaviour.', action='store_const', const=True, default=True)
     group.add_argument('--weights',           help='Initialize the model with weights from a file.')
+    group.add_argument('--no-weights',        help='Don\'t initialize the model with any weights.', dest='imagenet_weights', action='store_const', const=False)
 
     parser.add_argument('--batch-size',    help='Size of the batches.', default=1, type=int)
     parser.add_argument('--gpu',           help='Id of the GPU to use (as reported by nvidia-smi).')
@@ -291,7 +292,7 @@ def main(args=None):
     else:
         weights = args.weights
         # default to imagenet if nothing else is specified
-        if weights is None:
+        if weights is None and args.imagenet_weights:
             weights = download_imagenet(RESNET_BACKBONE)
 
         print('Creating model, this may take a second...')

--- a/keras_retinanet/models/resnet.py
+++ b/keras_retinanet/models/resnet.py
@@ -50,7 +50,7 @@ def download_imagenet(backbone):
     )
 
 
-def resnet_retinanet(num_classes, backbone=50, inputs=None, weights='imagenet', skip_mismatch=True, **kwargs):
+def resnet_retinanet(num_classes, backbone=50, inputs=None, **kwargs):
     allowed_backbones = [50, 101, 152]
     if backbone not in allowed_backbones:
         raise ValueError('Backbone (\'{}\') not in allowed backbones ({}).'.format(backbone, allowed_backbones))
@@ -58,14 +58,6 @@ def resnet_retinanet(num_classes, backbone=50, inputs=None, weights='imagenet', 
     # choose default input
     if inputs is None:
         inputs = keras.layers.Input(shape=(None, None, 3))
-
-    # determine which weights to load
-    if weights == 'imagenet':
-        weights_path = download_imagenet(backbone)
-    elif weights is None:
-        weights_path = None
-    else:
-        weights_path = weights
 
     # create the resnet backbone
     if backbone == 50:
@@ -78,35 +70,31 @@ def resnet_retinanet(num_classes, backbone=50, inputs=None, weights='imagenet', 
     # create the full model
     model = retinanet.retinanet_bbox(inputs=inputs, num_classes=num_classes, backbone=resnet, **kwargs)
 
-    # optionally load weights
-    if weights_path:
-        model.load_weights(weights_path, by_name=True, skip_mismatch=skip_mismatch)
-
     return model
 
 
-def resnet50_retinanet(num_classes, inputs=None, weights='imagenet', skip_mismatch=True, **kwargs):
-    return resnet_retinanet(num_classes=num_classes, backbone=50, inputs=inputs, weights=weights, skip_mismatch=skip_mismatch, **kwargs)
+def resnet50_retinanet(num_classes, inputs=None, weights='imagenet', **kwargs):
+    return resnet_retinanet(num_classes=num_classes, backbone=50, inputs=inputs, **kwargs)
 
 
-def resnet101_retinanet(num_classes, inputs=None, weights='imagenet', skip_mismatch=True, **kwargs):
-    return resnet_retinanet(num_classes=num_classes, backbone=101, inputs=inputs, weights=weights, skip_mismatch=skip_mismatch, **kwargs)
+def resnet101_retinanet(num_classes, inputs=None, weights='imagenet', **kwargs):
+    return resnet_retinanet(num_classes=num_classes, backbone=101, inputs=inputs, **kwargs)
 
 
-def resnet152_retinanet(num_classes, inputs=None, weights='imagenet', skip_mismatch=True, **kwargs):
-    return resnet_retinanet(num_classes=num_classes, backbone=152, inputs=inputs, weights=weights, skip_mismatch=skip_mismatch, **kwargs)
+def resnet152_retinanet(num_classes, inputs=None, weights='imagenet', **kwargs):
+    return resnet_retinanet(num_classes=num_classes, backbone=152, inputs=inputs, **kwargs)
 
 
-def ResNet50RetinaNet(inputs, num_classes, skip_mismatch=True, **kwargs):
+def ResNet50RetinaNet(inputs, num_classes, **kwargs):
     warnings.warn("ResNet50RetinaNet is replaced by resnet50_retinanet and will be removed in a future release.")
-    return resnet50_retinanet(num_classes, inputs, *args, skip_mismatch=skip_mismatch, **kwargs)
+    return resnet50_retinanet(num_classes, inputs, *args, **kwargs)
 
 
-def ResNet101RetinaNet(inputs, num_classes, skip_mismatch=True, **kwargs):
+def ResNet101RetinaNet(inputs, num_classes, **kwargs):
     warnings.warn("ResNet101RetinaNet is replaced by resnet101_retinanet and will be removed in a future release.")
-    return resnet101_retinanet(num_classes, inputs, *args, skip_mismatch=skip_mismatch, **kwargs)
+    return resnet101_retinanet(num_classes, inputs, *args, **kwargs)
 
 
-def ResNet152RetinaNet(inputs, num_classes, skip_mismatch=True, **kwargs):
+def ResNet152RetinaNet(inputs, num_classes, **kwargs):
     warnings.warn("ResNet152RetinaNet is replaced by resnet152_retinanet and will be removed in a future release.")
-    return resnet152_retinanet(num_classes, inputs, *args, skip_mismatch=skip_mismatch, **kwargs)
+    return resnet152_retinanet(num_classes, inputs, *args, **kwargs)


### PR DESCRIPTION
Currently, `train.py` doesn't allow training without weights because the command line arguments are passed down directly, and the default is "imagenet". That means there is no way to *not* load any weights right now.

This PR does two things:
* It moves loading of weights out of the retinanet-resnet model creation functions.
* It removes all special string values for weights loading. Instead, different flags indicate different types of weight initialization: `--snapshot <file>`, `--imagenet-weights`, `--weights <file>` or `--no-weights`. The default is still to initialize with imagenet weights.

Note: I only tested the argument parsing briefly. When I get back to the office (next week) I intend to test this more thoroughly to verify the actual runtime behaviour. But it can be reviewed already.