### PR TITLE
Option for the Evaluate callback to add mAP to Tensorboard

### DIFF
--- a/keras_retinanet/callbacks/eval.py
+++ b/keras_retinanet/callbacks/eval.py
@@ -15,7 +15,6 @@ limitations under the License.
 """
 
 import keras
-import tensorflow as tf
 from ..utils.eval import evaluate
 
 
@@ -29,16 +28,16 @@ class Evaluate(keras.callbacks.Callback):
             score_threshold : The score confidence threshold to use for detections.
             max_detections  : The maximum number of detections to use per image.
             save_path       : The path to save images with visualized detections to.
-            tensorboard     : Instance of keras.callbacks.TensorBoard used to log the mAP value
-            verbose         : Set the verbosity level, by default this is set to 1
+            tensorboard     : Instance of keras.callbacks.TensorBoard used to log the mAP value.
+            verbose         : Set the verbosity level, by default this is set to 1.
         """
         self.generator       = generator
         self.iou_threshold   = iou_threshold
         self.score_threshold = score_threshold
         self.max_detections  = max_detections
         self.save_path       = save_path
-        self.tensorboard = tensorboard
-        self.verbose = verbose
+        self.tensorboard     = tensorboard
+        self.verbose         = verbose
 
         super(Evaluate, self).__init__()
 
@@ -53,18 +52,17 @@ class Evaluate(keras.callbacks.Callback):
             save_path=self.save_path
         )
 
-        self.map = sum(average_precisions.values()) / len(average_precisions)
+        self.mean_ap = sum(average_precisions.values()) / len(average_precisions)
 
         if self.tensorboard is not None and self.tensorboard.writer is not None:
-
+            import tensorflow as tf
             summary = tf.Summary()
             summary_value = summary.value.add()
-            summary_value.simple_value = self.map
+            summary_value.simple_value = self.mean_ap
             summary_value.tag = "mAP"
             self.tensorboard.writer.add_summary(summary, epoch)
 
         if self.verbose == 1:
-
             for label, average_precision in average_precisions.items():
                 print(self.generator.label_to_name(label), '{:.4f}'.format(average_precision))
-            print('mAP: {:.4f}'.format(self.map))
+            print('mAP: {:.4f}'.format(self.mean_ap))

--- a/keras_retinanet/callbacks/eval.py
+++ b/keras_retinanet/callbacks/eval.py
@@ -15,11 +15,12 @@ limitations under the License.
 """
 
 import keras
+import tensorflow as tf
 from ..utils.eval import evaluate
 
 
 class Evaluate(keras.callbacks.Callback):
-    def __init__(self, generator, iou_threshold=0.5, score_threshold=0.05, max_detections=100, save_path=None):
+    def __init__(self, generator, iou_threshold=0.5, score_threshold=0.05, max_detections=100, save_path=None, tensorboard=None, verbose=1):
         """ Evaluate a given dataset using a given model at the end of every epoch during training.
 
         # Arguments
@@ -28,12 +29,16 @@ class Evaluate(keras.callbacks.Callback):
             score_threshold : The score confidence threshold to use for detections.
             max_detections  : The maximum number of detections to use per image.
             save_path       : The path to save images with visualized detections to.
+            tensorboard     : Instance of keras.callbacks.TensorBoard used to log the mAP value
+            verbose         : Set the verbosity level, by default this is set to 1
         """
         self.generator       = generator
         self.iou_threshold   = iou_threshold
         self.score_threshold = score_threshold
         self.max_detections  = max_detections
         self.save_path       = save_path
+        self.tensorboard = tensorboard
+        self.verbose = verbose
 
         super(Evaluate, self).__init__()
 
@@ -48,7 +53,18 @@ class Evaluate(keras.callbacks.Callback):
             save_path=self.save_path
         )
 
-        # print evaluation
-        for label, average_precision in average_precisions.items():
-            print(self.generator.label_to_name(label), '{:.4f}'.format(average_precision))
-        print('mAP: {:.4f}'.format(sum(average_precisions.values()) / len(average_precisions)))
+        self.map = sum(average_precisions.values()) / len(average_precisions)
+
+        if self.tensorboard is not None and self.tensorboard.writer is not None:
+
+            summary = tf.Summary()
+            summary_value = summary.value.add()
+            summary_value.simple_value = self.map
+            summary_value.tag = "mAP"
+            self.tensorboard.writer.add_summary(summary, epoch)
+
+        if self.verbose == 1:
+
+            for label, average_precision in average_precisions.items():
+                print(self.generator.label_to_name(label), '{:.4f}'.format(average_precision))
+            print('mAP: {:.4f}'.format(self.map))


### PR DESCRIPTION
This PR adds the option to allow the Evaluate callback to use an existing instance of `keras.callbacks.TensorBoard` to log the calculated mAP value to Tensorboard. This allows the mAP to be easily tracked without having to look at the console output or a log file.

I've opted for this approach to prevent having to ship a forked version of the original Keras Tensorboard callback to add mAP. I'm just hooking into the callback that the user has already set-up.

Additionally I've added a verbose option to disable the existing console output if desired, by default verbose mode is on (existing behavior).

Example usage:
```
tensorboard_cb = keras.callbacks.TensorBoard(
            log_dir                 = './tf-logs/,
            histogram_freq          = 0,
            batch_size              = 1,
            write_graph             = True,
            write_grads             = False,
            write_images            = False,
            embeddings_freq         = 0,
            embeddings_layer_names  = None,
            embeddings_metadata     = None
        )

callbacks.append(tensorboard_cb)

evaluation_cb = Evaluate(val_generator, tensorboard=tensorboard_cb, verbose=0)

callbacks.append(evaluation_cb)

```
Note: If PR #267 is accepted this could afterwards additionally be added to train.py to activate this by default if the user enables both the Tensorboard and evaluation options.