### PR TITLE
Add mAP to tensorboard when using train.py

### DIFF
--- a/keras_retinanet/bin/train.py
+++ b/keras_retinanet/bin/train.py
@@ -109,8 +109,10 @@ def create_callbacks(model, training_model, prediction_model, validation_generat
         checkpoint = RedirectModel(checkpoint, prediction_model)
         callbacks.append(checkpoint)
 
+    tensorboard_callback = None
+
     if args.tensorboard_dir:
-        tensorb = keras.callbacks.TensorBoard(
+        tensorboard_callback = keras.callbacks.TensorBoard(
             log_dir                = args.tensorboard_dir,
             histogram_freq         = 0,
             batch_size             = args.batch_size,
@@ -121,7 +123,7 @@ def create_callbacks(model, training_model, prediction_model, validation_generat
             embeddings_layer_names = None,
             embeddings_metadata    = None
         )
-        callbacks.append(tensorb)
+        callbacks.append(tensorboard_callback)
 
     if args.evaluation and validation_generator:
         if args.dataset_type == 'coco':
@@ -130,10 +132,7 @@ def create_callbacks(model, training_model, prediction_model, validation_generat
             # use prediction model for evaluation
             evaluation = CocoEval(validation_generator)
         else:
-            if args.tensorboard_dir:
-                evaluation = Evaluate(validation_generator, tensorboard=tensorb)
-            else:
-                evaluation = Evaluate(validation_generator)
+            evaluation = Evaluate(validation_generator, tensorboard=tensorboard_callback)
         evaluation = RedirectModel(evaluation, prediction_model)
         callbacks.append(evaluation)
 

--- a/keras_retinanet/bin/train.py
+++ b/keras_retinanet/bin/train.py
@@ -109,6 +109,20 @@ def create_callbacks(model, training_model, prediction_model, validation_generat
         checkpoint = RedirectModel(checkpoint, prediction_model)
         callbacks.append(checkpoint)
 
+    if args.tensorboard_dir:
+        tensorb = keras.callbacks.TensorBoard(
+            log_dir                = args.tensorboard_dir,
+            histogram_freq         = 0,
+            batch_size             = args.batch_size,
+            write_graph            = True,
+            write_grads            = False,
+            write_images           = False,
+            embeddings_freq        = 0,
+            embeddings_layer_names = None,
+            embeddings_metadata    = None
+        )
+        callbacks.append(tensorb)
+
     if args.evaluation and validation_generator:
         if args.dataset_type == 'coco':
             from ..callbacks.coco import CocoEval
@@ -116,7 +130,10 @@ def create_callbacks(model, training_model, prediction_model, validation_generat
             # use prediction model for evaluation
             evaluation = CocoEval(validation_generator)
         else:
-            evaluation = Evaluate(validation_generator)
+            if args.tensorboard_dir:
+                evaluation = Evaluate(validation_generator, tensorboard=tensorb)
+            else:
+                evaluation = Evaluate(validation_generator)
         evaluation = RedirectModel(evaluation, prediction_model)
         callbacks.append(evaluation)
 
@@ -130,19 +147,6 @@ def create_callbacks(model, training_model, prediction_model, validation_generat
         cooldown = 0,
         min_lr   = 0
     ))
-
-    if args.tensorboard_dir:
-        callbacks.append(keras.callbacks.TensorBoard(
-            log_dir                = args.tensorboard_dir,
-            histogram_freq         = 0,
-            batch_size             = args.batch_size,
-            write_graph            = True,
-            write_grads            = False,
-            write_images           = False,
-            embeddings_freq        = 0,
-            embeddings_layer_names = None,
-            embeddings_metadata    = None
-        ))
 
     return callbacks
 


### PR DESCRIPTION
If the user enables Tensorboard in `train.py` with `--tensorboard-dir` (introduced with #267) and has not disabled evaluation with `--no-evaluation` the mean_ap value will now be automatically added to TensorBoard (as introduced in #278).