### PR TITLE
compute true layer shapes + backbone VGG

### DIFF
--- a/keras_retinanet/bin/train.py
+++ b/keras_retinanet/bin/train.py
@@ -41,7 +41,9 @@ from ..preprocessing.csv_generator import CSVGenerator
 from ..preprocessing.open_images import OpenImagesGenerator
 from ..utils.transform import random_transform_generator
 from ..utils.keras_version import check_keras_version
-from ..utils.anchors import make_shapes_callback, freeze as freeze_model
+from ..utils.anchors import make_shapes_callback
+from ..utils.model import freeze as freeze_model
+
 
 
 def get_session():

--- a/keras_retinanet/bin/train.py
+++ b/keras_retinanet/bin/train.py
@@ -46,7 +46,6 @@ from ..utils.anchors import make_shapes_callback, anchor_targets_bbox
 from ..utils.model import freeze as freeze_model
 
 
-
 def get_session():
     config = tf.ConfigProto()
     config.gpu_options.allow_growth = True

--- a/keras_retinanet/bin/train.py
+++ b/keras_retinanet/bin/train.py
@@ -295,7 +295,7 @@ def parse_args(args):
     parser.add_argument('--tensorboard-dir', help='Log directory for Tensorboard output', default='./logs')
     parser.add_argument('--no-snapshots',    help='Disable saving snapshots.', dest='snapshots', action='store_false')
     parser.add_argument('--no-evaluation',   help='Disable per epoch evaluation.', dest='evaluation', action='store_false')
-    parser.add_argument('--true-shapes',     help='Use actual model to compute shapes of layers used for FPN.', dest='true_shapes', action='store_true', default=False)
+    parser.add_argument('--true-shapes',     help='Use actual model to compute shapes of layers used for FPN.', action='store_true', default=False)
 
     return check_args(parser.parse_args(args))
 

--- a/keras_retinanet/bin/train.py
+++ b/keras_retinanet/bin/train.py
@@ -365,7 +365,7 @@ def main(args=None):
     print(model.summary())
 
     # this lets the generator compute backbone layer shapes using the actual backbone model
-    if "vgg" in args.backbone:
+    if 'vgg' in args.backbone:
         shapes_callback = make_shapes_callback(model)
         train_generator.shapes_callback = shapes_callback
         if validation_generator is not None:

--- a/keras_retinanet/bin/train.py
+++ b/keras_retinanet/bin/train.py
@@ -41,6 +41,7 @@ from ..preprocessing.csv_generator import CSVGenerator
 from ..preprocessing.open_images import OpenImagesGenerator
 from ..utils.transform import random_transform_generator
 from ..utils.keras_version import check_keras_version
+from ..utils.anchors import make_shapes_callback
 
 
 def get_session():
@@ -295,7 +296,6 @@ def parse_args(args):
     parser.add_argument('--tensorboard-dir', help='Log directory for Tensorboard output', default='./logs')
     parser.add_argument('--no-snapshots',    help='Disable saving snapshots.', dest='snapshots', action='store_false')
     parser.add_argument('--no-evaluation',   help='Disable per epoch evaluation.', dest='evaluation', action='store_false')
-    parser.add_argument('--true-shapes',     help='Use actual model to compute shapes of layers used for FPN.', action='store_true', default=False)
 
     return check_args(parser.parse_args(args))
 
@@ -345,10 +345,11 @@ def main(args=None):
     print(model.summary())
 
     # this lets the generator compute backbone layer shapes using the actual backbone model
-    if args.true_shapes:
-        train_generator.model = model
+    if "vgg" in args.backbone:
+        shapes_callback = make_shapes_callback(model)
+        train_generator.shapes_callback = shapes_callback
         if validation_generator is not None:
-            validation_generator.model = model
+            validation_generator.shapes_callback = shapes_callback
 
     # create the callbacks
     callbacks = create_callbacks(

--- a/keras_retinanet/bin/train.py
+++ b/keras_retinanet/bin/train.py
@@ -17,6 +17,7 @@ limitations under the License.
 """
 
 import argparse
+import functools
 import os
 import sys
 
@@ -41,7 +42,7 @@ from ..preprocessing.csv_generator import CSVGenerator
 from ..preprocessing.open_images import OpenImagesGenerator
 from ..utils.transform import random_transform_generator
 from ..utils.keras_version import check_keras_version
-from ..utils.anchors import make_shapes_callback
+from ..utils.anchors import make_shapes_callback, anchor_targets_bbox
 from ..utils.model import freeze as freeze_model
 
 
@@ -366,10 +367,10 @@ def main(args=None):
 
     # this lets the generator compute backbone layer shapes using the actual backbone model
     if 'vgg' in args.backbone:
-        shapes_callback = make_shapes_callback(model)
-        train_generator.shapes_callback = shapes_callback
+        compute_anchor_targets = functools.partial(anchor_targets_bbox, shapes_callback=make_shapes_callback(model))
+        train_generator.compute_anchor_targets = compute_anchor_targets
         if validation_generator is not None:
-            validation_generator.shapes_callback = shapes_callback
+            validation_generator.compute_anchor_targets = compute_anchor_targets
 
     # create the callbacks
     callbacks = create_callbacks(

--- a/keras_retinanet/models/mobilenet.py
+++ b/keras_retinanet/models/mobilenet.py
@@ -83,14 +83,14 @@ def mobilenet_retinanet(num_classes, backbone='mobilenet224_1.0', inputs=None, m
 
     mobilenet = MobileNet(input_tensor=inputs, alpha=alpha, include_top=False, pooling=None, weights=None)
 
-    # invoke modifier if given
-    if modifier:
-        mobilenet = modifier(mobilenet)
 
     # create the full model
     layer_names = ['conv_pw_5_relu', 'conv_pw_11_relu', 'conv_pw_13_relu']
     layer_outputs = [mobilenet.get_layer(name).output for name in layer_names]
-    model = retinanet.retinanet_bbox(inputs=inputs, num_classes=num_classes,
-                                     backbone_layers=layer_outputs, **kwargs)
+    mobilenet = keras.models.Model(inputs=inputs, outputs=layer_outputs, name=mobilenet.name)
 
-    return model
+    # invoke modifier if given
+    if modifier:
+        mobilenet = modifier(mobilenet)
+
+    return retinanet.retinanet_bbox(inputs=inputs, num_classes=num_classes, backbone_layers=mobilenet.outputs, **kwargs)

--- a/keras_retinanet/models/mobilenet.py
+++ b/keras_retinanet/models/mobilenet.py
@@ -84,7 +84,9 @@ def mobilenet_retinanet(num_classes, backbone='mobilenet224_1.0', inputs=None, *
     mobilenet = MobileNet(input_tensor=inputs, alpha=alpha, include_top=False, pooling=None, weights=None)
 
     # create the full model
-    model = retinanet.retinanet_bbox(inputs=inputs, num_classes=num_classes, backbone=mobilenet,
-                                     backbone_layers=['conv_pw_5_relu', 'conv_pw_11_relu', 'conv_pw_13_relu'], **kwargs)
+    layer_names = ['conv_pw_5_relu', 'conv_pw_11_relu', 'conv_pw_13_relu']
+    layer_outputs = [mobilenet.get_layer(name).output for name in layer_names]
+    model = retinanet.retinanet_bbox(inputs=inputs, num_classes=num_classes,
+                                     backbone_layers=layer_outputs, **kwargs)
 
     return model

--- a/keras_retinanet/models/mobilenet.py
+++ b/keras_retinanet/models/mobilenet.py
@@ -83,13 +83,8 @@ def mobilenet_retinanet(num_classes, backbone='mobilenet224_1.0', inputs=None, *
 
     mobilenet = MobileNet(input_tensor=inputs, alpha=alpha, include_top=False, pooling=None, weights=None)
 
-    # get last layer from each depthwise convolution blocks 3, 5, 11 and 13
-    outputs = [mobilenet.get_layer(name='conv_pw_{}_relu'.format(i)).output for i in [3, 5, 11, 13]]
-
-    # create the mobilenet backbone
-    mobilenet = keras.models.Model(inputs=inputs, outputs=outputs, name=mobilenet.name)
-
     # create the full model
-    model = retinanet.retinanet_bbox(inputs=inputs, num_classes=num_classes, backbone=mobilenet, **kwargs)
+    model = retinanet.retinanet_bbox(inputs=inputs, num_classes=num_classes, backbone=mobilenet,
+                                     backbone_layers=['conv_pw_5_relu', 'conv_pw_11_relu', 'conv_pw_13_relu'], **kwargs)
 
     return model

--- a/keras_retinanet/models/mobilenet.py
+++ b/keras_retinanet/models/mobilenet.py
@@ -83,7 +83,6 @@ def mobilenet_retinanet(num_classes, backbone='mobilenet224_1.0', inputs=None, m
 
     mobilenet = MobileNet(input_tensor=inputs, alpha=alpha, include_top=False, pooling=None, weights=None)
 
-
     # create the full model
     layer_names = ['conv_pw_5_relu', 'conv_pw_11_relu', 'conv_pw_13_relu']
     layer_outputs = [mobilenet.get_layer(name).output for name in layer_names]

--- a/keras_retinanet/models/resnet.py
+++ b/keras_retinanet/models/resnet.py
@@ -77,12 +77,7 @@ def resnet_retinanet(num_classes, backbone='resnet50', inputs=None, modifier=Non
         resnet = modifier(resnet)
 
     # create the full model
-    layer_names = ["res3d_relu", "res4f_relu", "res5c_relu"]
-    layer_outputs = [resnet.get_layer(name).output for name in layer_names]
-    model = retinanet.retinanet_bbox(inputs=inputs, num_classes=num_classes,
-                                     backbone_layers=layer_outputs, **kwargs)
-
-    return model
+    return retinanet.retinanet_bbox(inputs=inputs, num_classes=num_classes, backbone_layers=resnet.outputs[1:], **kwargs)
 
 
 def resnet50_retinanet(num_classes, inputs=None, **kwargs):

--- a/keras_retinanet/models/resnet.py
+++ b/keras_retinanet/models/resnet.py
@@ -73,7 +73,8 @@ def resnet_retinanet(num_classes, backbone='resnet50', inputs=None, **kwargs):
         resnet = keras_resnet.models.ResNet152(inputs, include_top=False, freeze_bn=True)
 
     # create the full model
-    model = retinanet.retinanet_bbox(inputs=inputs, num_classes=num_classes, backbone=resnet, **kwargs)
+    model = retinanet.retinanet_bbox(inputs=inputs, num_classes=num_classes, backbone=resnet,
+                                     backbone_layers=["res3d_relu", "res4f_relu", "res5c_relu"], **kwargs)
 
     return model
 

--- a/keras_retinanet/models/resnet.py
+++ b/keras_retinanet/models/resnet.py
@@ -73,8 +73,10 @@ def resnet_retinanet(num_classes, backbone='resnet50', inputs=None, **kwargs):
         resnet = keras_resnet.models.ResNet152(inputs, include_top=False, freeze_bn=True)
 
     # create the full model
-    model = retinanet.retinanet_bbox(inputs=inputs, num_classes=num_classes, backbone=resnet,
-                                     backbone_layers=["res3d_relu", "res4f_relu", "res5c_relu"], **kwargs)
+    layer_names = ["res3d_relu", "res4f_relu", "res5c_relu"]
+    layer_outputs = [resnet.get_layer(name).output for name in layer_names]
+    model = retinanet.retinanet_bbox(inputs=inputs, num_classes=num_classes,
+                                     backbone_layers=layer_outputs, **kwargs)
 
     return model
 

--- a/keras_retinanet/models/retinanet.py
+++ b/keras_retinanet/models/retinanet.py
@@ -177,6 +177,7 @@ def __build_anchors(anchor_parameters, features):
 def retinanet(
     inputs,
     backbone,
+    backbone_layers,
     num_classes,
     anchor_parameters       = AnchorParameters.default,
     create_pyramid_features = __create_pyramid_features,
@@ -186,7 +187,7 @@ def retinanet(
     if submodels is None:
         submodels = default_submodels(num_classes, anchor_parameters)
 
-    _, C3, C4, C5 = backbone.outputs  # we ignore C2
+    C3, C4, C5 = [backbone.get_layer(name).output for name in backbone_layers]
 
     # compute pyramid features as per https://arxiv.org/abs/1708.02002
     features = create_pyramid_features(C3, C4, C5)

--- a/keras_retinanet/models/retinanet.py
+++ b/keras_retinanet/models/retinanet.py
@@ -176,7 +176,6 @@ def __build_anchors(anchor_parameters, features):
 
 def retinanet(
     inputs,
-    backbone,
     backbone_layers,
     num_classes,
     anchor_parameters       = AnchorParameters.default,
@@ -187,7 +186,7 @@ def retinanet(
     if submodels is None:
         submodels = default_submodels(num_classes, anchor_parameters)
 
-    C3, C4, C5 = [backbone.get_layer(name).output for name in backbone_layers]
+    C3, C4, C5 = backbone_layers
 
     # compute pyramid features as per https://arxiv.org/abs/1708.02002
     features = create_pyramid_features(C3, C4, C5)

--- a/keras_retinanet/models/vgg.py
+++ b/keras_retinanet/models/vgg.py
@@ -20,24 +20,21 @@ import keras
 from ..models import retinanet
 
 
-custom_objects = retinanet.custom_objects.copy()
+custom_objects = retinanet.custom_objects
 
 
 def download_imagenet(backbone):
-    backbone = int(backbone.replace('vgg', ''))
-
-    if backbone == 16:
+    if backbone == 'vgg16':
         resource = keras.applications.vgg16.WEIGHTS_PATH_NO_TOP
         checksum = '6d6bbae143d832006294945121d1f1fc'
-    elif backbone == 19:
+    elif backbone == 'vgg19':
         resource = keras.applications.vgg19.WEIGHTS_PATH_NO_TOP
         checksum = '253f8cb515780f3b799900260a226db6'
     else:
-        resource = None
-        checksum = None
+        raise ValueError("Backbone '{}' not recognized.")
 
     weights_path = keras.applications.imagenet_utils.get_file(
-        'vgg{}_weights_tf_dim_ordering_tf_kernels_notop.h5'.format(backbone),
+        '{}_weights_tf_dim_ordering_tf_kernels_notop.h5'.format(backbone),
         resource,
         cache_subdir='models',
         file_hash=checksum)

--- a/keras_retinanet/models/vgg.py
+++ b/keras_retinanet/models/vgg.py
@@ -49,7 +49,7 @@ def validate_backbone(backbone):
         raise ValueError('Backbone (\'{}\') not in allowed backbones ({}).'.format(backbone, allowed_backbones))
 
 
-def vgg_retinanet(num_classes, backbone='vgg16', inputs=None, **kwargs):
+def vgg_retinanet(num_classes, backbone='vgg16', inputs=None, modifier=None, **kwargs):
     # choose default input
     if inputs is None:
         inputs = keras.layers.Input(shape=(None, None, 3))
@@ -65,7 +65,4 @@ def vgg_retinanet(num_classes, backbone='vgg16', inputs=None, **kwargs):
     # create the full model
     layer_names = ["block3_pool", "block4_pool", "block5_pool"]
     layer_outputs = [vgg.get_layer(name).output for name in layer_names]
-    model = retinanet.retinanet_bbox(inputs=inputs, num_classes=num_classes,
-                                     backbone_layers=layer_outputs, **kwargs)
-
-    return model
+    return retinanet.retinanet_bbox(inputs=inputs, num_classes=num_classes, backbone_layers=layer_outputs, **kwargs)

--- a/keras_retinanet/models/vgg.py
+++ b/keras_retinanet/models/vgg.py
@@ -1,0 +1,72 @@
+"""
+Copyright 2017-2018 cgratie (https://github.com/cgratie/)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+
+import keras
+
+from ..models import retinanet
+
+
+custom_objects = retinanet.custom_objects.copy()
+
+
+def download_imagenet(backbone):
+    backbone = int(backbone.replace('vgg', ''))
+
+    if backbone == 16:
+        resource = keras.applications.vgg16.WEIGHTS_PATH_NO_TOP
+        checksum = '6d6bbae143d832006294945121d1f1fc'
+    elif backbone == 19:
+        resource = keras.applications.vgg19.WEIGHTS_PATH_NO_TOP
+        checksum = '253f8cb515780f3b799900260a226db6'
+    else:
+        resource = None
+        checksum = None
+
+    weights_path = keras.applications.imagenet_utils.get_file(
+        'vgg{}_weights_tf_dim_ordering_tf_kernels_notop.h5'.format(backbone),
+        resource,
+        cache_subdir='models',
+        file_hash=checksum)
+
+    return weights_path
+
+
+def validate_backbone(backbone):
+    allowed_backbones = ['vgg16', 'vgg19']
+
+    if backbone not in allowed_backbones:
+        raise ValueError('Backbone (\'{}\') not in allowed backbones ({}).'.format(backbone, allowed_backbones))
+
+
+def vgg_retinanet(num_classes, backbone='vgg16', inputs=None, **kwargs):
+    # choose default input
+    if inputs is None:
+        inputs = keras.layers.Input(shape=(None, None, 3))
+
+    # create the vgg backbone
+    if backbone == 'vgg16':
+        vgg = keras.applications.VGG16(input_tensor=inputs, include_top=False)
+    elif backbone == 'vgg19':
+        vgg = keras.applications.VGG19(input_tensor=inputs, include_top=False)
+    else:
+        vgg = None
+
+    # create the full model
+    model = retinanet.retinanet_bbox(inputs=inputs, num_classes=num_classes, backbone=vgg,
+                                     backbone_layers=["block3_pool", "block4_pool", "block5_pool"], **kwargs)
+
+    return model

--- a/keras_retinanet/models/vgg.py
+++ b/keras_retinanet/models/vgg.py
@@ -63,7 +63,9 @@ def vgg_retinanet(num_classes, backbone='vgg16', inputs=None, **kwargs):
         vgg = None
 
     # create the full model
-    model = retinanet.retinanet_bbox(inputs=inputs, num_classes=num_classes, backbone=vgg,
-                                     backbone_layers=["block3_pool", "block4_pool", "block5_pool"], **kwargs)
+    layer_names = ["block3_pool", "block4_pool", "block5_pool"]
+    layer_outputs = [vgg.get_layer(name).output for name in layer_names]
+    model = retinanet.retinanet_bbox(inputs=inputs, num_classes=num_classes,
+                                     backbone_layers=layer_outputs, **kwargs)
 
     return model

--- a/keras_retinanet/models/vgg.py
+++ b/keras_retinanet/models/vgg.py
@@ -31,7 +31,7 @@ def download_imagenet(backbone):
         resource = keras.applications.vgg19.WEIGHTS_PATH_NO_TOP
         checksum = '253f8cb515780f3b799900260a226db6'
     else:
-        raise ValueError("Backbone '{}' not recognized.")
+        raise ValueError("Backbone '{}' not recognized.".format(backbone))
 
     weights_path = keras.applications.imagenet_utils.get_file(
         '{}_weights_tf_dim_ordering_tf_kernels_notop.h5'.format(backbone),
@@ -60,7 +60,10 @@ def vgg_retinanet(num_classes, backbone='vgg16', inputs=None, modifier=None, **k
     elif backbone == 'vgg19':
         vgg = keras.applications.VGG19(input_tensor=inputs, include_top=False)
     else:
-        vgg = None
+        raise ValueError("Backbone '{}' not recognized.".format(backbone))
+
+    if modifier:
+        vgg = modifier(vgg)
 
     # create the full model
     layer_names = ["block3_pool", "block4_pool", "block5_pool"]

--- a/keras_retinanet/preprocessing/generator.py
+++ b/keras_retinanet/preprocessing/generator.py
@@ -203,7 +203,12 @@ class Generator(object):
         for index, (image, annotations) in enumerate(zip(image_group, annotations_group)):
             # compute regression targets
             labels_group[index], annotations, anchors = self.anchor_targets(
-                max_shape, annotations, self.num_classes(), mask_shape=image.shape, shapes_callback=self.shapes_callback)
+                max_shape,
+                annotations,
+                self.num_classes(),
+                mask_shape=image.shape,
+                shapes_callback=self.shapes_callback,
+            )
             regression_group[index] = bbox_transform(anchors, annotations)
 
             # append anchor states to regression targets (necessary for filtering 'ignore', 'positive' and 'negative' anchors)

--- a/keras_retinanet/preprocessing/generator.py
+++ b/keras_retinanet/preprocessing/generator.py
@@ -43,6 +43,7 @@ class Generator(object):
         image_min_side=600,
         image_max_side=1024,
         transform_parameters=None,
+        model=None,
     ):
         self.transform_generator  = transform_generator
         self.batch_size           = int(batch_size)
@@ -51,6 +52,7 @@ class Generator(object):
         self.image_min_side       = image_min_side
         self.image_max_side       = image_max_side
         self.transform_parameters = transform_parameters or TransformParameters()
+        self.model                = model
 
         self.group_index = 0
         self.lock        = threading.Lock()
@@ -200,7 +202,8 @@ class Generator(object):
         regression_group = [None] * self.batch_size
         for index, (image, annotations) in enumerate(zip(image_group, annotations_group)):
             # compute regression targets
-            labels_group[index], annotations, anchors = self.anchor_targets(max_shape, annotations, self.num_classes(), mask_shape=image.shape)
+            labels_group[index], annotations, anchors = self.anchor_targets(
+                max_shape, annotations, self.num_classes(), mask_shape=image.shape, model=self.model)
             regression_group[index] = bbox_transform(anchors, annotations)
 
             # append anchor states to regression targets (necessary for filtering 'ignore', 'positive' and 'negative' anchors)

--- a/keras_retinanet/preprocessing/generator.py
+++ b/keras_retinanet/preprocessing/generator.py
@@ -43,16 +43,16 @@ class Generator(object):
         image_min_side=800,
         image_max_side=1333,
         transform_parameters=None,
-        shapes_callback=None,
+        compute_anchor_targets=anchor_targets_bbox,
     ):
-        self.transform_generator  = transform_generator
-        self.batch_size           = int(batch_size)
-        self.group_method         = group_method
-        self.shuffle_groups       = shuffle_groups
-        self.image_min_side       = image_min_side
-        self.image_max_side       = image_max_side
-        self.transform_parameters = transform_parameters or TransformParameters()
-        self.shapes_callback      = shapes_callback
+        self.transform_generator    = transform_generator
+        self.batch_size             = int(batch_size)
+        self.group_method           = group_method
+        self.shuffle_groups         = shuffle_groups
+        self.image_min_side         = image_min_side
+        self.image_max_side         = image_max_side
+        self.transform_parameters   = transform_parameters or TransformParameters()
+        self.compute_anchor_targets = compute_anchor_targets
 
         self.group_index = 0
         self.lock        = threading.Lock()
@@ -181,18 +181,6 @@ class Generator(object):
 
         return image_batch
 
-    def anchor_targets(
-        self,
-        image_shape,
-        annotations,
-        num_classes,
-        mask_shape=None,
-        negative_overlap=0.4,
-        positive_overlap=0.5,
-        **kwargs
-    ):
-        return anchor_targets_bbox(image_shape, annotations, num_classes, mask_shape, negative_overlap, positive_overlap, **kwargs)
-
     def compute_targets(self, image_group, annotations_group):
         # get the max image shape
         max_shape = tuple(max(image.shape[x] for image in image_group) for x in range(3))
@@ -202,12 +190,11 @@ class Generator(object):
         regression_group = [None] * self.batch_size
         for index, (image, annotations) in enumerate(zip(image_group, annotations_group)):
             # compute regression targets
-            labels_group[index], annotations, anchors = self.anchor_targets(
+            labels_group[index], annotations, anchors = self.compute_anchor_targets(
                 max_shape,
                 annotations,
                 self.num_classes(),
                 mask_shape=image.shape,
-                shapes_callback=self.shapes_callback,
             )
             regression_group[index] = bbox_transform(anchors, annotations)
 

--- a/keras_retinanet/preprocessing/generator.py
+++ b/keras_retinanet/preprocessing/generator.py
@@ -43,7 +43,7 @@ class Generator(object):
         image_min_side=600,
         image_max_side=1024,
         transform_parameters=None,
-        model=None,
+        shapes_callback=None,
     ):
         self.transform_generator  = transform_generator
         self.batch_size           = int(batch_size)
@@ -52,7 +52,7 @@ class Generator(object):
         self.image_min_side       = image_min_side
         self.image_max_side       = image_max_side
         self.transform_parameters = transform_parameters or TransformParameters()
-        self.model                = model
+        self.shapes_callback      = shapes_callback
 
         self.group_index = 0
         self.lock        = threading.Lock()
@@ -203,7 +203,7 @@ class Generator(object):
         for index, (image, annotations) in enumerate(zip(image_group, annotations_group)):
             # compute regression targets
             labels_group[index], annotations, anchors = self.anchor_targets(
-                max_shape, annotations, self.num_classes(), mask_shape=image.shape, model=self.model)
+                max_shape, annotations, self.num_classes(), mask_shape=image.shape, shapes_callback=self.shapes_callback)
             regression_group[index] = bbox_transform(anchors, annotations)
 
             # append anchor states to regression targets (necessary for filtering 'ignore', 'positive' and 'negative' anchors)

--- a/tests/bin/test_train.py
+++ b/tests/bin/test_train.py
@@ -72,7 +72,6 @@ def test_vgg():
         '--epochs=1',
         '--steps=1',
         '--no-snapshots',
-        '--true-shapes',
         'coco',
         'tests/test-data/coco',
     ])

--- a/tests/bin/test_train.py
+++ b/tests/bin/test_train.py
@@ -27,6 +27,7 @@ def test_coco():
     keras_retinanet.bin.train.main([
         '--epochs=1',
         '--steps=1',
+        '--no-weights',
         '--no-snapshots',
         'coco',
         'tests/test-data/coco',
@@ -41,6 +42,7 @@ def test_pascal():
     keras_retinanet.bin.train.main([
         '--epochs=1',
         '--steps=1',
+        '--no-weights',
         '--no-snapshots',
         'pascal',
         'tests/test-data/pascal',
@@ -55,6 +57,7 @@ def test_csv():
     keras_retinanet.bin.train.main([
         '--epochs=1',
         '--steps=1',
+        '--no-weights',
         '--no-snapshots',
         'csv',
         'tests/test-data/csv/annotations.csv',
@@ -71,6 +74,7 @@ def test_vgg():
         '--backbone=vgg16',
         '--epochs=1',
         '--steps=1',
+        '--no-weights',
         '--no-snapshots',
         'coco',
         'tests/test-data/coco',

--- a/tests/bin/test_train.py
+++ b/tests/bin/test_train.py
@@ -60,3 +60,19 @@ def test_csv():
         'tests/test-data/csv/annotations.csv',
         'tests/test-data/csv/classes.csv',
     ])
+
+
+def test_vgg():
+    # ignore warnings in this test
+    warnings.simplefilter('ignore')
+
+    # run training / evaluation
+    keras_retinanet.bin.train.main([
+        '--backbone=vgg16',
+        '--epochs=1',
+        '--steps=1',
+        '--no-snapshots',
+        '--true-shapes',
+        'coco',
+        'tests/test-data/coco',
+    ])

--- a/tests/models/test_vgg.py
+++ b/tests/models/test_vgg.py
@@ -30,6 +30,7 @@ def test_vgg():
         '--steps=1',
         '--no-weights',
         '--no-snapshots',
+        '--freeze-backbone',
         'coco',
         'tests/test-data/coco',
     ])

--- a/tests/models/test_vgg.py
+++ b/tests/models/test_vgg.py
@@ -1,5 +1,5 @@
 """
-Copyright 2017-2018 Fizyr (https://fizyr.com)
+Copyright 2017-2018 cgratie (https://github.com/cgratie/)
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,47 +19,17 @@ import keras_retinanet.bin.train
 import warnings
 
 
-def test_coco():
+def test_vgg():
     # ignore warnings in this test
     warnings.simplefilter('ignore')
 
     # run training / evaluation
     keras_retinanet.bin.train.main([
+        '--backbone=vgg16',
         '--epochs=1',
         '--steps=1',
         '--no-weights',
         '--no-snapshots',
         'coco',
         'tests/test-data/coco',
-    ])
-
-
-def test_pascal():
-    # ignore warnings in this test
-    warnings.simplefilter('ignore')
-
-    # run training / evaluation
-    keras_retinanet.bin.train.main([
-        '--epochs=1',
-        '--steps=1',
-        '--no-weights',
-        '--no-snapshots',
-        'pascal',
-        'tests/test-data/pascal',
-    ])
-
-
-def test_csv():
-    # ignore warnings in this test
-    warnings.simplefilter('ignore')
-
-    # run training / evaluation
-    keras_retinanet.bin.train.main([
-        '--epochs=1',
-        '--steps=1',
-        '--no-weights',
-        '--no-snapshots',
-        'csv',
-        'tests/test-data/csv/annotations.csv',
-        'tests/test-data/csv/classes.csv',
     ])


### PR DESCRIPTION
This PR adds the VGG backbone, together with the following updates:
* `retinanet` from `retinanet.py` gets an additional argument `backbone_layers` which holds the names of the layers to use for generating the FPN; I have also updated the body of this function to use this argument. This makes it easier to add new backbones without being required to create an intermediary model that has those layers as outputs.
* function `anchors_for_shape` from `anchors.py` takes a new optional keyword argument `model`. If provided, the model is used for computing the actual layer shapes based on the input image. `Generator` also takes a `model` argument in order to pass it to `anchors_for_shape`.

I have also added a test for VGG in `test_train.py`. To see that computing the actual layer shapes is needed, replace default value `image_min_side=600` from `Generator` with `image_min_side=500`. With `"--true-shapes'` option in `test_vgg`, the test will still pass, without that it will fail.