### PR TITLE
draw_detections (in utils.visualization) fix, failed when not supplying a generator

### DIFF
--- a/keras_retinanet/utils/visualization.py
+++ b/keras_retinanet/utils/visualization.py
@@ -72,7 +72,7 @@ def draw_detections(image, detections, color=(255, 0, 0), generator=None):
     for d in detections:
         label   = np.argmax(d[4:])
         score   = d[4 + label]
-        caption = (generator.label_to_name(label) if generator else label) + ': {0:.2f}'.format(score)
+        caption = (generator.label_to_name(label) if generator else str(label)) + ': {0:.2f}'.format(score)
         draw_caption(image, d, caption)
 
 


### PR DESCRIPTION
```
caption = (generator.label_to_name(label) if generator else label) + ': {0:.2f}'.format(score)
```

Fails when not using a generator: the ```+``` operator doesn't work on ```label```, which is a float object