### PR TITLE
Fixup loss normalization

### DIFF
--- a/keras_retinanet/losses.py
+++ b/keras_retinanet/losses.py
@@ -23,19 +23,6 @@ def focal(alpha=0.25, gamma=2.0):
         labels         = y_true
         classification = y_pred
 
-        # compute the divisor: for each image in the batch, we want the number of positive anchors
-
-        # clip the labels to 0, 1 so that we ignore the "ignore" label (-1) in the divisor
-        divisor = backend.where(keras.backend.less_equal(labels, 0), keras.backend.zeros_like(labels), labels)
-        divisor = keras.backend.max(divisor, axis=2, keepdims=True)
-        divisor = keras.backend.cast(divisor, keras.backend.floatx())
-
-        # compute the number of positive anchors
-        divisor = keras.backend.sum(divisor, axis=1, keepdims=True)
-
-        #  ensure we do not divide by 0
-        divisor = keras.backend.maximum(1.0, divisor)
-
         # compute the focal loss
         alpha_factor = keras.backend.ones_like(labels) * alpha
         alpha_factor = backend.where(keras.backend.equal(labels, 1), alpha_factor, 1 - alpha_factor)
@@ -44,17 +31,17 @@ def focal(alpha=0.25, gamma=2.0):
 
         cls_loss = focal_weight * keras.backend.binary_crossentropy(labels, classification)
 
-        # normalise by the number of positive anchors for each entry in the minibatch
-        cls_loss = cls_loss / divisor
-
         # filter out "ignore" anchors
         anchor_state = keras.backend.max(labels, axis=2)  # -1 for ignore, 0 for background, 1 for object
         indices      = backend.where(keras.backend.not_equal(anchor_state, -1))
+        cls_loss     = backend.gather_nd(cls_loss, indices)
 
-        cls_loss = backend.gather_nd(cls_loss, indices)
+        # compute the normalizer: the number of positive anchors
+        normalizer = backend.where(keras.backend.equal(anchor_state, 1))
+        normalizer = keras.backend.cast(keras.backend.shape(normalizer)[0], keras.backend.floatx())
+        normalizer = keras.backend.maximum(1.0, normalizer)
 
-        # divide by the size of the minibatch
-        return keras.backend.sum(cls_loss) / keras.backend.cast(keras.backend.shape(labels)[0], keras.backend.floatx())
+        return keras.backend.sum(cls_loss) / normalizer
 
     return _focal
 
@@ -68,14 +55,6 @@ def smooth_l1(sigma=3.0):
         regression_target = y_true[:, :, :4]
         anchor_state      = y_true[:, :, 4]
 
-        # compute the divisor: for each image in the batch, we want the number of positive anchors
-        divisor = backend.where(keras.backend.equal(anchor_state, 1), keras.backend.ones_like(anchor_state), keras.backend.zeros_like(anchor_state))
-        divisor = keras.backend.sum(divisor, axis=1, keepdims=True)
-        divisor = keras.backend.maximum(1.0, divisor)
-
-        # pad the tensor to have shape (batch_size, 1, 1) for future division
-        divisor   = keras.backend.expand_dims(divisor, axis=2)
-
         # compute smooth L1 loss
         # f(x) = 0.5 * (sigma * x)^2          if |x| < 1 / sigma / sigma
         #        |x| - 0.5 / sigma / sigma    otherwise
@@ -87,16 +66,14 @@ def smooth_l1(sigma=3.0):
             regression_diff - 0.5 / sigma_squared
         )
 
-        # normalise by the number of positive and negative anchors for each entry in the minibatch
-        regression_loss = regression_loss / divisor
-
         # filter out "ignore" anchors
         indices         = backend.where(keras.backend.equal(anchor_state, 1))
         regression_loss = backend.gather_nd(regression_loss, indices)
 
-        # divide by the size of the minibatch
-        regression_loss = keras.backend.sum(regression_loss) / keras.backend.cast(keras.backend.shape(y_true)[0], keras.backend.floatx())
+        # compute the normalizer: the number of positive anchors
+        normalizer = keras.backend.maximum(1, keras.backend.shape(indices)[0])
+        normalizer = keras.backend.cast(keras.backend.maximum(1, normalizer), dtype=keras.backend.floatx())
 
-        return regression_loss
+        return keras.backend.sum(regression_loss) / normalizer
 
     return _smooth_l1

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -1,0 +1,32 @@
+import keras_retinanet.losses
+import keras
+
+import numpy as np
+
+import pytest
+
+def test_smooth_l1():
+    regression = np.array([
+        [
+            [0, 0, 0, 0],
+            [0, 0, 0, 0],
+            [0, 0, 0, 0],
+            [0, 0, 0, 0],
+        ]
+    ], dtype=keras.backend.floatx())
+    regression = keras.backend.variable(regression)
+
+    regression_target = np.array([
+        [
+            [0, 0, 0, 1, 1],
+            [0, 0, 1, 0, 1],
+            [0, 0, 0.05, 0, 1],
+            [0, 0, 1, 0, 0],
+        ]
+    ], dtype=keras.backend.floatx())
+    regression_target = keras.backend.variable(regression_target)
+
+    loss = keras_retinanet.losses.smooth_l1()(regression_target, regression)
+    loss = keras.backend.eval(loss)
+
+    assert loss == pytest.approx((((1 - 0.5 / 9) * 2 + (0.5 * 9 * 0.05 ** 2)) / 3))

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -5,6 +5,7 @@ import numpy as np
 
 import pytest
 
+
 def test_smooth_l1():
     regression = np.array([
         [


### PR DESCRIPTION
After careful inspection of Detectron, it appears our normalization of losses was slightly incorrect. We were normalizing each batch with the number of positive anchors in that batch, but every value should be divided by the total number of positive anchors. This PR fixes that and adds a unit test for the smooth L1 loss.