### PR TITLE
refactor import of Image submodule

### DIFF
--- a/keras_retinanet/utils/image.py
+++ b/keras_retinanet/utils/image.py
@@ -20,13 +20,13 @@ import time
 import numpy as np
 import scipy.ndimage as ndi
 import cv2
-import PIL
+from PIL import Image
 
 from .transform import change_transform_origin, transform_aabb
 
 
 def read_image_bgr(path):
-    image = np.asarray(PIL.Image.open(path).convert('RGB'))
+    image = np.asarray(Image.open(path).convert('RGB'))
     return image[:, :, ::-1].copy()
 
 


### PR DESCRIPTION
# What does this PR do?
Fix the conflict that arises from using the `Image` submodule of `pillow` package.
This issue is caused by the newest version of pillow, `5.0.0`.