### PR TITLE
Revert "Use nearest method for upsampling."

### DIFF
--- a/keras_retinanet/backend/tensorflow_backend.py
+++ b/keras_retinanet/backend/tensorflow_backend.py
@@ -34,14 +34,8 @@ def clip_by_value(*args, **kwargs):
     return tensorflow.clip_by_value(*args, **kwargs)
 
 
-def resize_images(*args, method='bilinear', **kwargs):
-    methods = {
-        'bilinear': tensorflow.image.ResizeMethod.BILINEAR,
-        'nearest' : tensorflow.image.ResizeMethod.NEAREST_NEIGHBOR,
-        'bicubic' : tensorflow.image.ResizeMethod.BICUBIC,
-        'area'    : tensorflow.image.ResizeMethod.AREA,
-    }
-    return tensorflow.image.resize_images(*args, method=methods[method], **kwargs)
+def resize_images(*args, **kwargs):
+    return tensorflow.image.resize_images(*args, **kwargs)
 
 
 def non_max_suppression(*args, **kwargs):

--- a/keras_retinanet/layers/_misc.py
+++ b/keras_retinanet/layers/_misc.py
@@ -79,7 +79,7 @@ class UpsampleLike(keras.layers.Layer):
     def call(self, inputs, **kwargs):
         source, target = inputs
         target_shape = keras.backend.shape(target)
-        return backend.resize_images(source, (target_shape[1], target_shape[2]), method='nearest')
+        return backend.resize_images(source, (target_shape[1], target_shape[2]))
 
     def compute_output_shape(self, input_shape):
         return (input_shape[0][0],) + input_shape[1][1:3] + (input_shape[0][-1],)


### PR DESCRIPTION
Reverts fizyr/keras-retinanet#442

Because CI failed.