### PR TITLE
Update Open Images Dataset version => V4 from 2018_04

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ The pretrained MS COCO model can be downloaded [here](https://github.com/fizyr/k
  Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.681
 ```
 
-For training on [OID](https://github.com/openimages/dataset), run:
+For training on Open Images Dataset [OID](https://storage.googleapis.com/openimages/web/index.html)
+or taking place taking place to the [OID challenges](https://storage.googleapis.com/openimages/web/challenge.html), run:
 ```shell
 # Running directly from the repository:
 keras_retinanet/bin/train.py oid /path/to/OID

--- a/keras_retinanet/bin/debug.py
+++ b/keras_retinanet/bin/debug.py
@@ -118,7 +118,7 @@ def parse_args(args):
     oid_parser = subparsers.add_parser('oid')
     oid_parser.add_argument('main_dir', help='Path to dataset directory.')
     oid_parser.add_argument('subset', help='Argument for loading a subset from train/validation/test.')
-    oid_parser.add_argument('--version',  help='The current dataset version is V3.', default='2017_11')
+    oid_parser.add_argument('--version',  help='The current dataset version is V4.', default='2018_04')
     oid_parser.add_argument('--labels-filter',  help='A list of labels to filter.', type=csv_list, default=None)
     oid_parser.add_argument('--annotation-cache-dir', help='Path to store annotation cache.', default='.')
     oid_parser.add_argument('--fixed-labels', help='Use the exact specified labels.', default=False)

--- a/keras_retinanet/bin/train.py
+++ b/keras_retinanet/bin/train.py
@@ -330,7 +330,7 @@ def parse_args(args):
 
     oid_parser = subparsers.add_parser('oid')
     oid_parser.add_argument('main_dir', help='Path to dataset directory.')
-    oid_parser.add_argument('--version',  help='The current dataset version is V3.', default='2017_11')
+    oid_parser.add_argument('--version',  help='The current dataset version is V4.', default='2018_04')
     oid_parser.add_argument('--labels-filter',  help='A list of labels to filter.', type=csv_list, default=None)
     oid_parser.add_argument('--annotation-cache-dir', help='Path to store annotation cache.', default='.')
     oid_parser.add_argument('--fixed-labels', help='Use the exact specified labels.', default=False)


### PR DESCRIPTION
A new version of this dataset has been released by Google in april: https://storage.googleapis.com/openimages/web/index.html.

An official challenge based on this dataset will be held on Kaggle and will try to replace PASCAL VOC and MSCOCO challenges:https://storage.googleapis.com/openimages/web/challenge.html.

It will be a great thing to advertise this project and its OID integration in order to allow kagglers to compete by using retinanet.

A new PR (or a new commit into this PR) will follow and include the particular challenge subset. The competition validation subset is still not available for the moment but should be released soon.