### PR TITLE
Reordering callbacks to allow monitoring the mean average precision

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -35,3 +35,4 @@ please create an issue or pull request at https://github.com/fizyr/keras-retinan
 * Guillaume Erhard
 * Eduardo Ramos
 * DiegoAgher
+* Alexander Pacha

--- a/keras_retinanet/bin/train.py
+++ b/keras_retinanet/bin/train.py
@@ -141,9 +141,9 @@ def create_callbacks(model, training_model, prediction_model, validation_generat
                 '{backbone}_{dataset_type}_{{epoch:02d}}.h5'.format(backbone=args.backbone, dataset_type=args.dataset_type)
             ),
             verbose=1,
-            save_best_only=True,
-            monitor="mAP",
-            mode='max'
+            # save_best_only=True,
+            # monitor="mAP",
+            # mode='max'
         )
         checkpoint = RedirectModel(checkpoint, model)
         callbacks.append(checkpoint)

--- a/keras_retinanet/bin/train.py
+++ b/keras_retinanet/bin/train.py
@@ -104,20 +104,6 @@ def create_models(backbone_retinanet, num_classes, weights, multi_gpu=0, freeze_
 def create_callbacks(model, training_model, prediction_model, validation_generator, args):
     callbacks = []
 
-    # save the model
-    if args.snapshots:
-        # ensure directory created first; otherwise h5py will error after epoch.
-        makedirs(args.snapshot_path)
-        checkpoint = keras.callbacks.ModelCheckpoint(
-            os.path.join(
-                args.snapshot_path,
-                '{backbone}_{dataset_type}_{{epoch:02d}}.h5'.format(backbone=args.backbone, dataset_type=args.dataset_type)
-            ),
-            verbose=1
-        )
-        checkpoint = RedirectModel(checkpoint, model)
-        callbacks.append(checkpoint)
-
     tensorboard_callback = None
 
     if args.tensorboard_dir:
@@ -144,6 +130,23 @@ def create_callbacks(model, training_model, prediction_model, validation_generat
             evaluation = Evaluate(validation_generator, tensorboard=tensorboard_callback)
         evaluation = RedirectModel(evaluation, prediction_model)
         callbacks.append(evaluation)
+
+    # save the model
+    if args.snapshots:
+        # ensure directory created first; otherwise h5py will error after epoch.
+        makedirs(args.snapshot_path)
+        checkpoint = keras.callbacks.ModelCheckpoint(
+            os.path.join(
+                args.snapshot_path,
+                '{backbone}_{dataset_type}_{{epoch:02d}}.h5'.format(backbone=args.backbone, dataset_type=args.dataset_type)
+            ),
+            verbose=1,
+            save_best_only=True,
+            monitor="mAP",
+            mode='max'
+        )
+        checkpoint = RedirectModel(checkpoint, model)
+        callbacks.append(checkpoint)
 
     callbacks.append(keras.callbacks.ReduceLROnPlateau(
         monitor  = 'loss',

--- a/keras_retinanet/callbacks/coco.py
+++ b/keras_retinanet/callbacks/coco.py
@@ -26,7 +26,9 @@ class CocoEval(keras.callbacks.Callback):
 
         super(CocoEval, self).__init__()
 
-    def on_epoch_end(self, epoch, logs={}):
+    def on_epoch_end(self, epoch, logs=None):
+        logs = logs or {}
+
         coco_tag = ['AP @[ IoU=0.50:0.95 | area=   all | maxDets=100 ]',
                     'AP @[ IoU=0.50      | area=   all | maxDets=100 ]',
                     'AP @[ IoU=0.75      | area=   all | maxDets=100 ]',
@@ -48,3 +50,4 @@ class CocoEval(keras.callbacks.Callback):
                 summary_value.simple_value = result
                 summary_value.tag = '{}. {}'.format(index + 1, coco_tag[index])
                 self.tensorboard.writer.add_summary(summary, epoch)
+                logs[coco_tag[index]] = result

--- a/keras_retinanet/callbacks/eval.py
+++ b/keras_retinanet/callbacks/eval.py
@@ -41,7 +41,9 @@ class Evaluate(keras.callbacks.Callback):
 
         super(Evaluate, self).__init__()
 
-    def on_epoch_end(self, epoch, logs={}):
+    def on_epoch_end(self, epoch, logs=None):
+        logs = logs or {}
+
         # run evaluation
         average_precisions = evaluate(
             self.generator,
@@ -61,6 +63,8 @@ class Evaluate(keras.callbacks.Callback):
             summary_value.simple_value = self.mean_ap
             summary_value.tag = "mAP"
             self.tensorboard.writer.add_summary(summary, epoch)
+
+        logs['mAP'] = self.mean_ap
 
         if self.verbose == 1:
             for label, average_precision in average_precisions.items():


### PR DESCRIPTION
Two changes:
- Writing mAP into logs dictionary in `eval.py` to allow monitoring that value
- Reordering the creation of callbacks, so the `ModelCheckpoint` already sees the validation metric and can potentially use it, to only save the best model.