### PR TITLE
Typo in variable name: 'backbone' --> 'self.backbone'

### DIFF
--- a/keras_retinanet/models/vgg.py
+++ b/keras_retinanet/models/vgg.py
@@ -53,7 +53,7 @@ class VGGBackbone(Backbone):
         allowed_backbones = ['vgg16', 'vgg19']
 
         if self.backbone not in allowed_backbones:
-            raise ValueError('Backbone (\'{}\') not in allowed backbones ({}).'.format(backbone, allowed_backbones))
+            raise ValueError('Backbone (\'{}\') not in allowed backbones ({}).'.format(self.backbone, allowed_backbones))
 
 
 def vgg_retinanet(num_classes, backbone='vgg16', inputs=None, modifier=None, **kwargs):


### PR DESCRIPTION
__backbone__ is an _undefined name_ in this context.

Discovered via https://travis-ci.org/fizyr/keras-retinanet/jobs/385214667#L751