### PR TITLE
Keras 2.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
     - '2.7'
 install:
     - pip install 'numpy>=1.14'
-    - pip install 'keras==2.1.3'
+    - pip install 'keras==2.2.0'
     - pip install 'opencv-python>=3.3.0'
     - pip install 'pillow'
     - pip install 'tensorflow'

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ by Tsung-Yi Lin, Priya Goyal, Ross Girshick, Kaiming He and Piotr Dollár.
    Note that due to inconsistencies with how `tensorflow` should be installed,
    this package does not define a dependency on `tensorflow` as it will try to install that (which at least on Arch Linux results in an incorrect installation).
    Please make sure `tensorflow` is installed as per your systems requirements.
-   Also, make sure Keras 2.1.3 or higher is installed.
 3) Optionally, install `pycocotools` if you want to train / test on the MS COCO dataset by running `pip install --user git+https://github.com/cocodataset/cocoapi.git#subdirectory=PythonAPI`.
 
 ## Testing
@@ -229,7 +228,7 @@ Example output images using `keras-retinanet` are shown below.
 If you have a project based on `keras-retinanet` and would like to have it published here, shoot me a message on Slack.
 
 ### Notes
-* This repository requires Keras 2.1.3 or higher.
+* This repository requires Keras 2.2.0 or higher.
 * This repository is [tested](https://github.com/fizyr/keras-retinanet/blob/master/.travis.yml) using OpenCV 3.4.
 * This repository is [tested](https://github.com/fizyr/keras-retinanet/blob/master/.travis.yml) using Python 2.7 and 3.6.
 

--- a/keras_retinanet/models/densenet.py
+++ b/keras_retinanet/models/densenet.py
@@ -15,7 +15,8 @@ limitations under the License.
 """
 
 import keras
-from keras.applications.densenet import DenseNet, get_file
+from keras.applications.densenet import densenet
+from keras.utils import get_file
 
 from . import retinanet
 from . import Backbone
@@ -75,19 +76,19 @@ def densenet_retinanet(num_classes, backbone='densenet121', inputs=None, modifie
         inputs = keras.layers.Input((None, None, 3))
 
     blocks = allowed_backbones[backbone]
-    densenet = DenseNet(blocks=blocks, input_tensor=inputs, include_top=False, pooling=None, weights=None)
+    backbone = densenet.DenseNet(blocks=blocks, input_tensor=inputs, include_top=False, pooling=None, weights=None)
 
     # get last conv layer from the end of each dense block
-    layer_outputs = [densenet.get_layer(name='conv{}_block{}_concat'.format(idx + 2, block_num)).output for idx, block_num in enumerate(blocks)]
+    layer_outputs = [backbone.get_layer(name='conv{}_block{}_concat'.format(idx + 2, block_num)).output for idx, block_num in enumerate(blocks)]
 
     # create the densenet backbone
-    densenet = keras.models.Model(inputs=inputs, outputs=layer_outputs[1:], name=densenet.name)
+    backbone = keras.models.Model(inputs=inputs, outputs=layer_outputs[1:], name=backbone.name)
 
     # invoke modifier if given
     if modifier:
-        densenet = modifier(densenet)
+        backbone = modifier(backbone)
 
     # create the full model
-    model = retinanet.retinanet(inputs=inputs, num_classes=num_classes, backbone_layers=densenet.outputs, **kwargs)
+    model = retinanet.retinanet(inputs=inputs, num_classes=num_classes, backbone_layers=backbone.outputs, **kwargs)
 
     return model

--- a/keras_retinanet/utils/keras_version.py
+++ b/keras_retinanet/utils/keras_version.py
@@ -19,7 +19,7 @@ from __future__ import print_function
 import keras
 import sys
 
-minimum_keras_version = 2, 1, 3
+minimum_keras_version = 2, 2, 0
 
 
 def keras_version():


### PR DESCRIPTION
These changes fix keras-retinanet for keras version 2.2.0. The only difference is that keras moved some imports to separate repositories and didn't preserve backwards compatibility..