### PR TITLE
Add option for class specific filtering.

### DIFF
--- a/keras_retinanet/bin/convert_model.py
+++ b/keras_retinanet/bin/convert_model.py
@@ -37,6 +37,7 @@ def parse_args(args):
     parser.add_argument('model_out', help='Path to save the converted model to.')
     parser.add_argument('--backbone', help='The backbone of the model to convert.', default='resnet50')
     parser.add_argument('--no-nms', help='Disables non maximum suppression.', dest='nms', action='store_false')
+    parser.add_argument('--no-class-specific-filter', help='Disables class specific filtering.', dest='class_specific_filter', action='store_false')
 
     return parser.parse_args(args)
 

--- a/keras_retinanet/layers/filter_detections.py
+++ b/keras_retinanet/layers/filter_detections.py
@@ -18,17 +18,27 @@ import keras
 from .. import backend
 
 
-def filter_detections(boxes, classification, other=[], nms=True, score_threshold=0.05, max_detections=300, nms_threshold=0.5):
+def filter_detections(
+    boxes,
+    classification,
+    other                 = [],
+    class_specific_filter = True,
+    nms                   = True,
+    score_threshold       = 0.05,
+    max_detections        = 300,
+    nms_threshold         = 0.5
+):
     """ Filter detections using the boxes and classification values.
 
     Args
-        boxes           : Tensor of shape (num_boxes, 4) containing the boxes in (x1, y1, x2, y2) format.
-        classification  : Tensor of shape (num_boxes, num_classes) containing the classification scores.
-        other           : List of tensors of shape (num_boxes, ...) to filter along with the boxes and classification scores.
-        nms             : Flag to enable/disable non maximum suppression.
-        score_threshold : Threshold used to prefilter the boxes with.
-        max_detections  : Maximum number of detections to keep.
-        nms_threshold   : Threshold for the IoU value to determine when a box should be suppressed.
+        boxes                 : Tensor of shape (num_boxes, 4) containing the boxes in (x1, y1, x2, y2) format.
+        classification        : Tensor of shape (num_boxes, num_classes) containing the classification scores.
+        other                 : List of tensors of shape (num_boxes, ...) to filter along with the boxes and classification scores.
+        class_specific_filter : Whether to perform filtering per class, or take the best scoring class and filter those.
+        nms                   : Flag to enable/disable non maximum suppression.
+        score_threshold       : Threshold used to prefilter the boxes with.
+        max_detections        : Maximum number of detections to keep.
+        nms_threshold         : Threshold for the IoU value to determine when a box should be suppressed.
 
     Returns
         A list of [boxes, scores, labels, other[0], other[1], ...].
@@ -38,12 +48,7 @@ def filter_detections(boxes, classification, other=[], nms=True, score_threshold
         other[i] is shaped (max_detections, ...) and contains the filtered other[i] data.
         In case there are less than max_detections detections, the tensors are padded with -1's.
     """
-    all_indices = []
-
-    # perform per class filtering
-    for c in range(int(classification.shape[1])):
-        scores = classification[:, c]
-
+    def _filter_detections(scores, labels):
         # threshold based on score
         indices = backend.where(keras.backend.greater(scores, score_threshold))
 
@@ -58,12 +63,25 @@ def filter_detections(boxes, classification, other=[], nms=True, score_threshold
             indices = keras.backend.gather(indices, nms_indices)
 
         # add indices to list of all indices
-        labels  = c * keras.backend.ones((keras.backend.shape(indices)[0],), dtype='int64')
+        labels = backend.gather_nd(labels, indices)
         indices = keras.backend.stack([indices[:, 0], labels], axis=1)
-        all_indices.append(indices)
 
-    # concatenate indices to single tensor
-    indices = keras.backend.concatenate(all_indices, axis=0)
+        return indices
+
+    if class_specific_filter:
+        all_indices = []
+        # perform per class filtering
+        for c in range(int(classification.shape[1])):
+            scores = classification[:, c]
+            labels = c * keras.backend.ones((keras.backend.shape(scores)[0],), dtype='int64')
+            all_indices.append(_filter_detections(scores, labels))
+
+        # concatenate indices to single tensor
+        indices = keras.backend.concatenate(all_indices, axis=0)
+    else:
+        scores  = keras.backend.max(classification, axis    = 1)
+        labels  = keras.backend.argmax(classification, axis = 1)
+        indices = _filter_detections(scores, labels)
 
     # select top k
     scores              = backend.gather_nd(classification, indices)
@@ -100,27 +118,30 @@ class FilterDetections(keras.layers.Layer):
 
     def __init__(
         self,
-        nms                 = True,
-        nms_threshold       = 0.5,
-        score_threshold     = 0.05,
-        max_detections      = 300,
-        parallel_iterations = 32,
+        nms                   = True,
+        class_specific_filter = True,
+        nms_threshold         = 0.5,
+        score_threshold       = 0.05,
+        max_detections        = 300,
+        parallel_iterations   = 32,
         **kwargs
     ):
         """ Filters detections using score threshold, NMS and selecting the top-k detections.
 
         Args
-            nms                 : Flag to enable/disable NMS.
-            nms_threshold       : Threshold for the IoU value to determine when a box should be suppressed.
-            score_threshold     : Threshold used to prefilter the boxes with.
-            max_detections      : Maximum number of detections to keep.
-            parallel_iterations : Number of batch items to process in parallel.
+            nms                   : Flag to enable/disable NMS.
+            class_specific_filter : Whether to perform filtering per class, or take the best scoring class and filter those.
+            nms_threshold         : Threshold for the IoU value to determine when a box should be suppressed.
+            score_threshold       : Threshold used to prefilter the boxes with.
+            max_detections        : Maximum number of detections to keep.
+            parallel_iterations   : Number of batch items to process in parallel.
         """
-        self.nms                 = nms
-        self.nms_threshold       = nms_threshold
-        self.score_threshold     = score_threshold
-        self.max_detections      = max_detections
-        self.parallel_iterations = parallel_iterations
+        self.nms                   = nms
+        self.class_specific_filter = class_specific_filter
+        self.nms_threshold         = nms_threshold
+        self.score_threshold       = score_threshold
+        self.max_detections        = max_detections
+        self.parallel_iterations   = parallel_iterations
         super(FilterDetections, self).__init__(**kwargs)
 
     def call(self, inputs, **kwargs):
@@ -143,10 +164,11 @@ class FilterDetections(keras.layers.Layer):
                 boxes,
                 classification,
                 other,
-                nms=self.nms,
-                score_threshold=self.score_threshold,
-                max_detections=self.max_detections,
-                nms_threshold=self.nms_threshold,
+                nms                   = self.nms,
+                class_specific_filter = self.class_specific_filter,
+                score_threshold       = self.score_threshold,
+                max_detections        = self.max_detections,
+                nms_threshold         = self.nms_threshold,
             )
 
         # call filter_detections on each batch
@@ -190,11 +212,12 @@ class FilterDetections(keras.layers.Layer):
         """
         config = super(FilterDetections, self).get_config()
         config.update({
-            'nms'                 : self.nms,
-            'nms_threshold'       : self.nms_threshold,
-            'score_threshold'     : self.score_threshold,
-            'max_detections'      : self.max_detections,
-            'parallel_iterations' : self.parallel_iterations,
+            'nms'                   : self.nms,
+            'class_specific_filter' : self.class_specific_filter,
+            'nms_threshold'         : self.nms_threshold,
+            'score_threshold'       : self.score_threshold,
+            'max_detections'        : self.max_detections,
+            'parallel_iterations'   : self.parallel_iterations,
         })
 
         return config

--- a/keras_retinanet/models/__init__.py
+++ b/keras_retinanet/models/__init__.py
@@ -53,16 +53,17 @@ def backbone(backbone_name):
     return b(backbone_name)
 
 
-def load_model(filepath, backbone_name='resnet50', convert=False, nms=True):
+def load_model(filepath, backbone_name='resnet50', convert=False, nms=True, class_specific_filter=True):
     """ Loads a retinanet model using the correct custom objects.
 
     # Arguments
         filepath: one of the following:
             - string, path to the saved model, or
             - h5py.File object from which to load the model
-        backbone_name: Backbone with which the model was trained.
-        convert: Boolean, whether to convert the model to an inference model.
-        nms: Boolean, whether to add NMS filtering to the converted model. Only valid if convert=True.
+        backbone_name         : Backbone with which the model was trained.
+        convert               : Boolean, whether to convert the model to an inference model.
+        nms                   : Boolean, whether to add NMS filtering to the converted model. Only valid if convert=True.
+        class_specific_filter : Whether to use class specific filtering or filter for the best scoring class only.
 
     # Returns
         A keras.models.Model object.
@@ -76,6 +77,6 @@ def load_model(filepath, backbone_name='resnet50', convert=False, nms=True):
     model = keras.models.load_model(filepath, custom_objects=backbone(backbone_name).custom_objects)
     if convert:
         from .retinanet import retinanet_bbox
-        model = retinanet_bbox(model=model, nms=nms)
+        model = retinanet_bbox(model=model, nms=nms, class_specific_filter=class_specific_filter)
 
     return model

--- a/keras_retinanet/models/retinanet.py
+++ b/keras_retinanet/models/retinanet.py
@@ -300,10 +300,11 @@ def retinanet(
 
 
 def retinanet_bbox(
-    model             = None,
-    anchor_parameters = AnchorParameters.default,
-    nms               = True,
-    name              = 'retinanet-bbox',
+    model                 = None,
+    anchor_parameters     = AnchorParameters.default,
+    nms                   = True,
+    class_specific_filter = True,
+    name                  = 'retinanet-bbox',
     **kwargs
 ):
     """ Construct a RetinaNet model on top of a backbone and adds convenience functions to output boxes directly.
@@ -312,10 +313,12 @@ def retinanet_bbox(
     These layers include applying the regression values to the anchors and performing NMS.
 
     Args
-        model             : RetinaNet model to append bbox layers to. If None, it will create a RetinaNet model using **kwargs.
-        anchor_parameters : Struct containing configuration for anchor generation (sizes, strides, ratios, scales).
-        name              : Name of the model.
-        *kwargs           : Additional kwargs to pass to the minimal retinanet model.
+        model                 : RetinaNet model to append bbox layers to. If None, it will create a RetinaNet model using **kwargs.
+        anchor_parameters     : Struct containing configuration for anchor generation (sizes, strides, ratios, scales).
+        nms                   : Whether to use non-maximum suppression for the filtering step.
+        class_specific_filter : Whether to use class specific filtering or filter for the best scoring class only.
+        name                  : Name of the model.
+        *kwargs               : Additional kwargs to pass to the minimal retinanet model.
 
     Returns
         A keras.models.Model which takes an image as input and outputs the detections on the image.
@@ -346,7 +349,11 @@ def retinanet_bbox(
     boxes = layers.ClipBoxes(name='clipped_boxes')([model.inputs[0], boxes])
 
     # filter detections (apply NMS / score threshold / select top-k)
-    detections = layers.FilterDetections(nms=nms, name='filtered_detections')([boxes, classification] + other)
+    detections = layers.FilterDetections(
+        nms                   = nms,
+        class_specific_filter = class_specific_filter,
+        name                  = 'filtered_detections'
+    )([boxes, classification] + other)
 
     outputs = detections
 


### PR DESCRIPTION
This PR adds a flag to disable class specific filtering. When disabled, each anchor would take the maximum scoring class and use that, instead of using all classes that have a score above a certain threshold.