### PR TITLE
Enable backbone specific image preprocessing.

### DIFF
--- a/keras_retinanet/bin/train.py
+++ b/keras_retinanet/bin/train.py
@@ -196,9 +196,20 @@ def create_callbacks(model, training_model, prediction_model, validation_generat
     return callbacks
 
 
-def create_generators(args):
+def create_generators(args, preprocess_image):
     """ Create generators for training and validation.
+
+    Args
+        args             : parseargs object containing configuration for generators.
+        preprocess_image : Function that preprocesses an image for the network.
     """
+    common_args = {
+        'batch_size'       : args.batch_size,
+        'image_min_side'   : args.image_min_side,
+        'image_max_side'   : args.image_max_side,
+        'preprocess_image' : preprocess_image,
+    }
+
     # create random transform generator for augmenting training data
     if args.random_transform:
         transform_generator = random_transform_generator(
@@ -224,52 +235,40 @@ def create_generators(args):
             args.coco_path,
             'train2017',
             transform_generator=transform_generator,
-            batch_size=args.batch_size,
-            image_min_side=args.image_min_side,
-            image_max_side=args.image_max_side
+            **common_args
         )
 
         validation_generator = CocoGenerator(
             args.coco_path,
             'val2017',
-            batch_size=args.batch_size,
-            image_min_side=args.image_min_side,
-            image_max_side=args.image_max_side
+            **common_args
         )
     elif args.dataset_type == 'pascal':
         train_generator = PascalVocGenerator(
             args.pascal_path,
             'trainval',
             transform_generator=transform_generator,
-            batch_size=args.batch_size,
-            image_min_side=args.image_min_side,
-            image_max_side=args.image_max_side
+            **common_args
         )
 
         validation_generator = PascalVocGenerator(
             args.pascal_path,
             'test',
-            batch_size=args.batch_size,
-            image_min_side=args.image_min_side,
-            image_max_side=args.image_max_side
+            **common_args
         )
     elif args.dataset_type == 'csv':
         train_generator = CSVGenerator(
             args.annotations,
             args.classes,
             transform_generator=transform_generator,
-            batch_size=args.batch_size,
-            image_min_side=args.image_min_side,
-            image_max_side=args.image_max_side
+            **common_args
         )
 
         if args.val_annotations:
             validation_generator = CSVGenerator(
                 args.val_annotations,
                 args.classes,
-                batch_size=args.batch_size,
-                image_min_side=args.image_min_side,
-                image_max_side=args.image_max_side
+                **common_args
             )
         else:
             validation_generator = None
@@ -282,9 +281,7 @@ def create_generators(args):
             annotation_cache_dir=args.annotation_cache_dir,
             fixed_labels=args.fixed_labels,
             transform_generator=transform_generator,
-            batch_size=args.batch_size,
-            image_min_side=args.image_min_side,
-            image_max_side=args.image_max_side
+            **common_args
         )
 
         validation_generator = OpenImagesGenerator(
@@ -294,26 +291,20 @@ def create_generators(args):
             labels_filter=args.labels_filter,
             annotation_cache_dir=args.annotation_cache_dir,
             fixed_labels=args.fixed_labels,
-            batch_size=args.batch_size,
-            image_min_side=args.image_min_side,
-            image_max_side=args.image_max_side
+            **common_args
         )
     elif args.dataset_type == 'kitti':
         train_generator = KittiGenerator(
             args.kitti_path,
             subset='train',
             transform_generator=transform_generator,
-            batch_size=args.batch_size,
-            image_min_side=args.image_min_side,
-            image_max_side=args.image_max_side
+            **common_args
         )
 
         validation_generator = KittiGenerator(
             args.kitti_path,
             subset='val',
-            batch_size=args.batch_size,
-            image_min_side=args.image_min_side,
-            image_max_side=args.image_max_side
+            **common_args
         )
     else:
         raise ValueError('Invalid data type received: {}'.format(args.dataset_type))
@@ -426,7 +417,7 @@ def main(args=None):
     keras.backend.tensorflow_backend.set_session(get_session())
 
     # create the generators
-    train_generator, validation_generator = create_generators(args)
+    train_generator, validation_generator = create_generators(args, backbone.preprocess_image)
 
     # create the model
     if args.snapshot is not None:
@@ -454,9 +445,9 @@ def main(args=None):
 
     # this lets the generator compute backbone layer shapes using the actual backbone model
     if 'vgg' in args.backbone or 'densenet' in args.backbone:
-        train_generator.compute_shapes         = make_shapes_callback(model)
-        if validation_generator is not None:
-            validation_generator.compute_shapes         = make_shapes_callback(model)
+        train_generator.compute_shapes = make_shapes_callback(model)
+        if validation_generator:
+            validation_generator.compute_shapes = train_generator.compute_shapes
 
     # create the callbacks
     callbacks = create_callbacks(

--- a/keras_retinanet/models/__init__.py
+++ b/keras_retinanet/models/__init__.py
@@ -35,6 +35,12 @@ class Backbone(object):
         """
         raise NotImplementedError('validate method not implemented.')
 
+    def preprocess_image(self, inputs):
+        """ Takes as input an image and prepares it for being passed through the network.
+        Having this function in Backbone allows other backbones to define a specific preprocessing step.
+        """
+        raise NotImplementedError('preprocess_image method not implemented.')
+
 
 def backbone(backbone_name):
     """ Returns a backbone object for the given backbone.

--- a/keras_retinanet/models/densenet.py
+++ b/keras_retinanet/models/densenet.py
@@ -20,6 +20,7 @@ from keras.utils import get_file
 
 from . import retinanet
 from . import Backbone
+from ..utils.image import preprocess_image
 
 allowed_backbones = {'densenet121': [6, 12, 24, 16], 'densenet169': [6, 12, 32, 32], 'densenet201': [6, 12, 48, 32]}
 
@@ -57,6 +58,11 @@ class DenseNetBackbone(Backbone):
 
         if backbone not in allowed_backbones:
             raise ValueError('Backbone (\'{}\') not in allowed backbones ({}).'.format(backbone, allowed_backbones.keys()))
+
+    def preprocess_image(self, inputs):
+        """ Takes as input an image and prepares it for being passed through the network.
+        """
+        return preprocess_image(inputs, mode='tf')
 
 
 def densenet_retinanet(num_classes, backbone='densenet121', inputs=None, modifier=None, **kwargs):

--- a/keras_retinanet/models/mobilenet.py
+++ b/keras_retinanet/models/mobilenet.py
@@ -17,6 +17,7 @@ limitations under the License.
 import keras
 from keras.applications.mobilenet import mobilenet
 from keras.utils import get_file
+from ..utils.image import preprocess_image
 
 from . import retinanet
 from . import Backbone
@@ -77,6 +78,11 @@ class MobileNetBackbone(Backbone):
 
         if backbone not in MobileNetBackbone.allowed_backbones:
             raise ValueError('Backbone (\'{}\') not in allowed backbones ({}).'.format(backbone, MobileNetBackbone.allowed_backbones))
+
+    def preprocess_image(self, inputs):
+        """ Takes as input an image and prepares it for being passed through the network.
+        """
+        return preprocess_image(inputs, mode='tf')
 
 
 def mobilenet_retinanet(num_classes, backbone='mobilenet224_1.0', inputs=None, modifier=None, **kwargs):

--- a/keras_retinanet/models/resnet.py
+++ b/keras_retinanet/models/resnet.py
@@ -18,8 +18,10 @@ import keras
 from keras.utils import get_file
 import keras_resnet
 import keras_resnet.models
+
 from . import retinanet
 from . import Backbone
+from ..utils.image import preprocess_image
 
 
 class ResNetBackbone(Backbone):
@@ -66,6 +68,11 @@ class ResNetBackbone(Backbone):
 
         if backbone not in allowed_backbones:
             raise ValueError('Backbone (\'{}\') not in allowed backbones ({}).'.format(backbone, allowed_backbones))
+
+    def preprocess_image(self, inputs):
+        """ Takes as input an image and prepares it for being passed through the network.
+        """
+        return preprocess_image(inputs, mode='caffe')
 
 
 def resnet_retinanet(num_classes, backbone='resnet50', inputs=None, modifier=None, **kwargs):

--- a/keras_retinanet/models/vgg.py
+++ b/keras_retinanet/models/vgg.py
@@ -20,6 +20,7 @@ from keras.utils import get_file
 
 from . import retinanet
 from . import Backbone
+from ..utils.image import preprocess_image
 
 
 class VGGBackbone(Backbone):
@@ -58,6 +59,11 @@ class VGGBackbone(Backbone):
 
         if self.backbone not in allowed_backbones:
             raise ValueError('Backbone (\'{}\') not in allowed backbones ({}).'.format(self.backbone, allowed_backbones))
+
+    def preprocess_image(self, inputs):
+        """ Takes as input an image and prepares it for being passed through the network.
+        """
+        return preprocess_image(inputs, mode='caffe')
 
 
 def vgg_retinanet(num_classes, backbone='vgg16', inputs=None, modifier=None, **kwargs):

--- a/keras_retinanet/preprocessing/generator.py
+++ b/keras_retinanet/preprocessing/generator.py
@@ -52,6 +52,7 @@ class Generator(object):
         transform_parameters=None,
         compute_anchor_targets=anchor_targets_bbox,
         compute_shapes=guess_shapes,
+        preprocess_image=preprocess_image,
     ):
         """ Initialize Generator object.
 
@@ -65,6 +66,7 @@ class Generator(object):
             transform_parameters   : The transform parameters used for data augmentation.
             compute_anchor_targets : Function handler for computing the targets of anchors for an image and its annotations.
             compute_shapes         : Function handler for computing the shapes of the pyramid for a given input.
+            preprocess_image       : Function handler for preprocessing an image (scaling / normalizing) for passing through a network.
         """
         self.transform_generator    = transform_generator
         self.batch_size             = int(batch_size)
@@ -75,6 +77,7 @@ class Generator(object):
         self.transform_parameters   = transform_parameters or TransformParameters()
         self.compute_anchor_targets = compute_anchor_targets
         self.compute_shapes         = compute_shapes
+        self.preprocess_image       = preprocess_image
 
         self.group_index = 0
         self.lock        = threading.Lock()
@@ -173,11 +176,6 @@ class Generator(object):
         """ Resize an image using image_min_side and image_max_side.
         """
         return resize_image(image, min_side=self.image_min_side, max_side=self.image_max_side)
-
-    def preprocess_image(self, image):
-        """ Preprocess an image (e.g. subtracts ImageNet mean).
-        """
-        return preprocess_image(image)
 
     def preprocess_group_entry(self, image, annotations):
         """ Preprocess image and its annotations.

--- a/keras_retinanet/utils/image.py
+++ b/keras_retinanet/utils/image.py
@@ -33,31 +33,39 @@ def read_image_bgr(path):
     return image[:, :, ::-1].copy()
 
 
-def preprocess_image(x):
+def preprocess_image(x, mode='caffe'):
     """ Preprocess an image by subtracting the ImageNet mean.
 
     Args
         x: np.array of shape (None, None, 3) or (3, None, None).
+        mode: One of "caffe" or "tf".
+            - caffe: will zero-center each color channel with
+                respect to the ImageNet dataset, without scaling.
+            - tf: will scale pixels between -1 and 1, sample-wise.
 
     Returns
         The input with the ImageNet mean subtracted.
     """
-    # mostly identical to "https://github.com/fchollet/keras/blob/master/keras/applications/imagenet_utils.py"
+    # mostly identical to "https://github.com/keras-team/keras-applications/blob/master/keras_applications/imagenet_utils.py"
     # except for converting RGB -> BGR since we assume BGR already
     x = x.astype(keras.backend.floatx())
-    if keras.backend.image_data_format() == 'channels_first':
-        if x.ndim == 3:
-            x[0, :, :] -= 103.939
-            x[1, :, :] -= 116.779
-            x[2, :, :] -= 123.68
+    if mode == 'tf':
+        x /= 127.5
+        x -= 1.
+    elif mode == 'caffe':
+        if keras.backend.image_data_format() == 'channels_first':
+            if x.ndim == 3:
+                x[0, :, :] -= 103.939
+                x[1, :, :] -= 116.779
+                x[2, :, :] -= 123.68
+            else:
+                x[:, 0, :, :] -= 103.939
+                x[:, 1, :, :] -= 116.779
+                x[:, 2, :, :] -= 123.68
         else:
-            x[:, 0, :, :] -= 103.939
-            x[:, 1, :, :] -= 116.779
-            x[:, 2, :, :] -= 123.68
-    else:
-        x[..., 0] -= 103.939
-        x[..., 1] -= 116.779
-        x[..., 2] -= 123.68
+            x[..., 0] -= 103.939
+            x[..., 1] -= 116.779
+            x[..., 2] -= 123.68
 
     return x
 


### PR DESCRIPTION
This PR enables backbones to define a specific form of image preprocessing. MobileNet and ResNet require different preprocessing on an image (one divides by 127.5 and normalizes to [-1, 1], the other subtracts the imagenet mean from the BGR channels).

@enricoliscio @vcarpani please review

ps. I based this PR off of the `optimizations` branch because it will likely be merged soon.