### PR TITLE
Ignore error for missing classes in CSVGenerator.

### DIFF
--- a/keras_retinanet/preprocessing/coco.py
+++ b/keras_retinanet/preprocessing/coco.py
@@ -75,6 +75,16 @@ class CocoGenerator(Generator):
         """
         return len(self.classes)
 
+    def has_label(self, label):
+        """ Return True if label is a known label.
+        """
+        return label in self.labels
+
+    def has_name(self, name):
+        """ Returns True if name is a known class.
+        """
+        return name in self.classes
+
     def name_to_label(self, name):
         """ Map name to label.
         """

--- a/keras_retinanet/preprocessing/csv_generator.py
+++ b/keras_retinanet/preprocessing/csv_generator.py
@@ -169,6 +169,16 @@ class CSVGenerator(Generator):
         """
         return max(self.classes.values()) + 1
 
+    def has_label(self, label):
+        """ Return True if label is a known label.
+        """
+        return label in self.labels
+
+    def has_name(self, name):
+        """ Returns True if name is a known class.
+        """
+        return name in self.classes
+
     def name_to_label(self, name):
         """ Map name to label.
         """

--- a/keras_retinanet/preprocessing/generator.py
+++ b/keras_retinanet/preprocessing/generator.py
@@ -96,6 +96,16 @@ class Generator(object):
         """
         raise NotImplementedError('num_classes method not implemented')
 
+    def has_label(self, label):
+        """ Returns True if label is a known label.
+        """
+        raise NotImplementedError('has_label method not implemented')
+
+    def has_name(self, name):
+        """ Returns True if name is a known class.
+        """
+        raise NotImplementedError('has_name method not implemented')
+
     def name_to_label(self, name):
         """ Map name to label.
         """

--- a/keras_retinanet/preprocessing/kitti.py
+++ b/keras_retinanet/preprocessing/kitti.py
@@ -76,9 +76,10 @@ class KittiGenerator(Generator):
         1    rotation_y   Rotation ry around Y-axis in camera coordinates [-pi..pi]
         """
 
-        self.id_to_labels = {}
-        for label, id in kitti_classes.items():
-            self.id_to_labels[id] = label
+        self.labels = {}
+        self.classes = kitti_classes
+        for name, label in self.classes.items():
+            self.labels[label] = name
 
         self.image_data = dict()
         self.images = []
@@ -112,7 +113,17 @@ class KittiGenerator(Generator):
     def num_classes(self):
         """ Number of classes in the dataset.
         """
-        return max(kitti_classes.values()) + 1
+        return max(self.classes.values()) + 1
+
+    def has_label(self, label):
+        """ Return True if label is a known label.
+        """
+        return label in self.labels
+
+    def has_name(self, name):
+        """ Returns True if name is a known class.
+        """
+        return name in self.classes
 
     def name_to_label(self, name):
         """ Map name to label.
@@ -122,7 +133,7 @@ class KittiGenerator(Generator):
     def label_to_name(self, label):
         """ Map label to name.
         """
-        return self.id_to_labels[label]
+        return self.labels[label]
 
     def image_aspect_ratio(self, image_index):
         """ Compute the aspect ratio for an image with image_index.

--- a/keras_retinanet/preprocessing/open_images.py
+++ b/keras_retinanet/preprocessing/open_images.py
@@ -324,6 +324,16 @@ class OpenImagesGenerator(Generator):
     def num_classes(self):
         return len(self.id_to_labels)
 
+    def has_label(self, label):
+        """ Return True if label is a known label.
+        """
+        return label in self.id_to_labels
+
+    def has_name(self, name):
+        """ Returns True if name is a known class.
+        """
+        raise NotImplementedError()
+
     def name_to_label(self, name):
         raise NotImplementedError()
 

--- a/keras_retinanet/preprocessing/pascal_voc.py
+++ b/keras_retinanet/preprocessing/pascal_voc.py
@@ -112,6 +112,16 @@ class PascalVocGenerator(Generator):
         """
         return len(self.classes)
 
+    def has_label(self, label):
+        """ Return True if label is a known label.
+        """
+        return label in self.labels
+
+    def has_name(self, name):
+        """ Returns True if name is a known class.
+        """
+        return name in self.classes
+
     def name_to_label(self, name):
         """ Map name to label.
         """

--- a/keras_retinanet/utils/eval.py
+++ b/keras_retinanet/utils/eval.py
@@ -70,7 +70,7 @@ def _get_detections(generator, model, score_threshold=0.05, max_detections=100, 
     # Returns
         A list of lists containing the detections for each image in the generator.
     """
-    all_detections = [[None for i in range(generator.num_classes())] for j in range(generator.size())]
+    all_detections = [[None for i in range(generator.num_classes()) if generator.has_label(i)] for j in range(generator.size())]
 
     for i in range(generator.size()):
         raw_image    = generator.load_image(i)
@@ -109,6 +109,9 @@ def _get_detections(generator, model, score_threshold=0.05, max_detections=100, 
 
         # copy detections to all_detections
         for label in range(generator.num_classes()):
+            if not generator.has_label(label):
+                continue
+
             all_detections[i][label] = image_detections[image_detections[:, -1] == label, :-1]
 
         print('{}/{}'.format(i + 1, generator.size()), end='\r')
@@ -135,6 +138,9 @@ def _get_annotations(generator):
 
         # copy detections to all_annotations
         for label in range(generator.num_classes()):
+            if not generator.has_label(label):
+                continue
+
             all_annotations[i][label] = annotations['bboxes'][annotations['labels'] == label, :].copy()
 
         print('{}/{}'.format(i + 1, generator.size()), end='\r')
@@ -174,6 +180,9 @@ def evaluate(
 
     # process detections and annotations
     for label in range(generator.num_classes()):
+        if not generator.has_label(label):
+            continue
+
         false_positives = np.zeros((0,))
         true_positives  = np.zeros((0,))
         scores          = np.zeros((0,))


### PR DESCRIPTION
Gaps can exist in the `CSVGenerator`, which results in errors when evaluating (https://github.com/fizyr/keras-retinanet/issues/565). This should ignore the KeyError when non-existing classes are used.

Alternatively (or in addition?) we could add a `has_label` and `has_classname` method to `Generator`, but I'm not sure if that is the correct approach.