### PR TITLE
 OID dataset: add option to choose a branch in the semantic hierarchical tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ retinanet-train oid /path/to/OID
 # You can also specify a list of labels if you want to train on a subset
 # by adding the argument 'labels_filter':
 keras_retinanet/bin/train.py oid /path/to/OID --labels_filter=Helmet,Tree
+
+# You can also specify a parent label if you want to train on a branch
+# from the semantic hierarchical tree (i.e a parent and all children)
+(https://storage.googleapis.com/openimages/challenge_2018/bbox_labels_500_hierarchy_visualizer/circle.html)
+# by adding the argument 'parent_label':
+keras_retinanet/bin/train.py oid /path/to/OID --parent_label=Boat
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ keras_retinanet/bin/train.py oid /path/to/OID --labels_filter=Helmet,Tree
 # You can also specify a parent label if you want to train on a branch
 # from the semantic hierarchical tree (i.e a parent and all children)
 (https://storage.googleapis.com/openimages/challenge_2018/bbox_labels_500_hierarchy_visualizer/circle.html)
-# by adding the argument 'parent_label':
-keras_retinanet/bin/train.py oid /path/to/OID --parent_label=Boat
+# by adding the argument 'parent-label':
+keras_retinanet/bin/train.py oid /path/to/OID --parent-label=Boat
 ```
 
 

--- a/keras_retinanet/bin/debug.py
+++ b/keras_retinanet/bin/debug.py
@@ -90,7 +90,7 @@ def create_generator(args):
             subset=args.subset,
             version=args.version,
             labels_filter=args.labels_filter,
-            fixed_labels=args.fixed_labels,
+            parent_label=args.parent_label,
             annotation_cache_dir=args.annotation_cache_dir,
             transform_generator=transform_generator,
             image_min_side=args.image_min_side,
@@ -138,7 +138,7 @@ def parse_args(args):
     oid_parser.add_argument('--version',  help='The current dataset version is v4.', default='v4')
     oid_parser.add_argument('--labels-filter',  help='A list of labels to filter.', type=csv_list, default=None)
     oid_parser.add_argument('--annotation-cache-dir', help='Path to store annotation cache.', default='.')
-    oid_parser.add_argument('--fixed-labels', help='Use the exact specified labels.', default=False)
+    oid_parser.add_argument('--parent-label', help='Use the hierarchy children of this label.', default=None)
 
     csv_parser = subparsers.add_parser('csv')
     csv_parser.add_argument('annotations', help='Path to CSV file containing annotations for evaluation.')

--- a/keras_retinanet/bin/train.py
+++ b/keras_retinanet/bin/train.py
@@ -279,7 +279,7 @@ def create_generators(args, preprocess_image):
             version=args.version,
             labels_filter=args.labels_filter,
             annotation_cache_dir=args.annotation_cache_dir,
-            fixed_labels=args.fixed_labels,
+            parent_label=args.parent_label,
             transform_generator=transform_generator,
             **common_args
         )
@@ -290,7 +290,7 @@ def create_generators(args, preprocess_image):
             version=args.version,
             labels_filter=args.labels_filter,
             annotation_cache_dir=args.annotation_cache_dir,
-            fixed_labels=args.fixed_labels,
+            parent_label=args.parent_label,
             **common_args
         )
     elif args.dataset_type == 'kitti':
@@ -367,7 +367,7 @@ def parse_args(args):
     oid_parser.add_argument('--version',  help='The current dataset version is v4.', default='v4')
     oid_parser.add_argument('--labels-filter',  help='A list of labels to filter.', type=csv_list, default=None)
     oid_parser.add_argument('--annotation-cache-dir', help='Path to store annotation cache.', default='.')
-    oid_parser.add_argument('--fixed-labels', help='Use the exact specified labels.', default=False)
+    oid_parser.add_argument('--parent-label', help='Use the hierarchy children of this label.', default=None)
 
     csv_parser = subparsers.add_parser('csv')
     csv_parser.add_argument('annotations', help='Path to CSV file containing annotations for training.')

--- a/keras_retinanet/preprocessing/open_images.py
+++ b/keras_retinanet/preprocessing/open_images.py
@@ -269,14 +269,14 @@ class OpenImagesGenerator(Generator):
             # there is/are no other sublabel(s) other than the labels itself
 
             for label in labels_filter:
-                for i, l in id_to_labels:
-                    if l == label:
+                for i, lb in id_to_labels:
+                    if lb == label:
                         children_id_to_labels[i] = label
                         break
         else:
             parent_cls = None
-            for i, l in id_to_labels.iteritems():
-                if l == parent_label:
+            for i, lb in id_to_labels.iteritems():
+                if lb == parent_label:
                     parent_id = i
                     for c, index in cls_index.iteritems():
                         if index == parent_id:
@@ -298,7 +298,7 @@ class OpenImagesGenerator(Generator):
                 label = id_to_labels[index]
                 children_id_to_labels[index] = label
 
-        id_map = dict([(index, i) for i, index in enumerate(children_id_to_labels.iterkeys())])
+        id_map = dict([(ind, i) for i, ind in enumerate(children_id_to_labels.iterkeys())])
 
         filtered_annotations = {}
         for k in self.annotations:


### PR DESCRIPTION
If you take for example the branch of the parent "Boat" in this tree (https://storage.googleapis.com/openimages/challenge_2018/bbox_labels_500_hierarchy_visualizer/circle.html) you will train on the subset containing annotations for Boat & children (Barge, Gondola, Canoe).
