### PR TITLE
fix load_model call in the example notebook

### DIFF
--- a/examples/ResNet50RetinaNet.ipynb
+++ b/examples/ResNet50RetinaNet.ipynb
@@ -94,7 +94,7 @@
     "\n",
     "# if the model is not converted to an inference model, use the line below\n",
     "# see: https://github.com/fizyr/keras-retinanet#converting-a-training-model-to-inference-model\n",
-    "#model = models.load_model(model_path, backbone_name='resnet50', convert_model=True)\n",
+    "#model = models.load_model(model_path, backbone_name='resnet50', convert=True)\n",
     "\n",
     "#print(model.summary())\n",
     "\n",


### PR DESCRIPTION
Just a quick fix of the `load_model` function call in the example notebook. See issue #575.