### PR TITLE
Tweak issue template.

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,13 +1,17 @@
-Please make sure that the boxes below are checked before you submit your issue. Only use GitHub issues for issues with the implementation, not for issues with specific datasets or general questions about functionality. If your issue is an implementation question, please ask your question on the [#keras-retinanet Slack channel](https://github.com/fizyr/keras-retinanet#discussions) and ask there instead of filing a GitHub issue.
+Please make sure that you follow the steps below when creating an issue.
+Only use GitHub issues for issues with the implementation, not for issues with specific datasets or general questions about functionality.
+If your issue is an implementation question, please ask your question on the #keras-retinanet Slack channel instead of filing a GitHub issue.
+You can find directions for the Slack channel here: https://github.com/fizyr/keras-retinanet#discussions
 
 Thank you!
 
-- [ ] Check that you are up-to-date with the master branch of keras-retinanet.
-
-- [ ] Check that you are up-to-date with the latest version of [Keras](https://github.com/keras-team/keras). 
-
-- [ ] Check that you are up-to-date with the latest version of TensorFlow. The installation instructions can be found [here](https://www.tensorflow.org/get_started/os_setup).
-
-- [ ] Check that you have read the entire [README.md](https://github.com/fizyr/keras-retinanet/README.md). Most noticably the [FAQ](https://github.com/fizyr/keras-retinanet#faq) section shows common issues.
-
-- [ ] Provide a link to a GitHub Gist of a Python script that can reproduce your issue (or just copy the script here if it is short).
+1. Check that you are up-to-date with the master branch of keras-retinanet.
+2. Check that you are up-to-date with the latest version of Keras: https://github.com/keras-team/keras.
+3. Check that you are up-to-date with the latest version of TensorFlow.
+   The installation instructions can be found here: https://www.tensorflow.org/get_started/os_setup.
+4. Check that you have read the entire README.md: https://github.com/fizyr/keras-retinanet/README.md.
+   Most noticably the FAQ section shows common issues: https://github.com/fizyr/keras-retinanet#faq.
+5. Clearly describe the issues you're having including the expected behaviour, the actual behaviour
+   and the steps required to trigger the issue.
+6. Include relevant output from the commands you're executing, including full stack traces where relevant.
+7. Remove this entire message and replace it with your issue.


### PR DESCRIPTION
This PR tweaks the issue template a bit.

Mainly, it changes the checkboxes into a numbered list and adds a request to remove the entire template to be replaced with the actual issue. The checkboxes sort-of imply that they should be ticked and remain in the issue, but I atleast prefer not to have them present in all issues.

I also changed the request for a script to these two points:
> * Clearly describe the issues you're having including the expected behaviour, the actual behaviour and the steps required to trigger the issue.
> * Include relevant output from the commands you're executing, including full stack traces where relevant.

I think in most situations it is more useful to know the commands being executed and their output than to always ask for a python script that triggers the issue. It can be a lot of work to make a minimal example, often for little gain. If something is complicated enough to warrant a minimum working example, we can still ask for one of course.