### PR TITLE
open_images.py quick fix

### DIFF
--- a/keras_retinanet/preprocessing/open_images.py
+++ b/keras_retinanet/preprocessing/open_images.py
@@ -117,7 +117,7 @@ def generate_images_annotations_json(main_dir, metadata_dir, subset, cls_index, 
 
         with open(validation_image_ids_path, 'r') as csv_file:
             reader = csv.DictReader(csv_file, fieldnames=['ImageID'])
-            reader.next()
+            next(reader)
             for line, row in enumerate(reader):
                 image_id = row['ImageID']
                 validation_image_ids[image_id] = True


### PR DESCRIPTION
 next(reader) replacing reader.next()

In Python 3.6.5 there is an AttributeError: 'DictReader' object has no attribute 'next' and this fixes it. #604