### PR TITLE
debug.py --anchors option now shows the positive anchors

### DIFF
--- a/keras_retinanet/bin/debug.py
+++ b/keras_retinanet/bin/debug.py
@@ -184,7 +184,7 @@ def run(generator, args):
 
         # draw anchors on the image
         if args.anchors:
-            draw_boxes(image, boxes_batch[0, anchor_states == 1, :], (0, 255, 0), thickness=1)
+            draw_boxes(image, anchors[anchor_states == 1], (255, 255, 0), thickness=1)
 
         # draw annotations on the image
         if args.annotations:


### PR DESCRIPTION
There was a bug that --anchors argument didn't show positive anchors in debug.py, but only the annotations. It is now fixed.

Old code screenshot:
![image](https://user-images.githubusercontent.com/3453282/43674054-1225b63c-97d6-11e8-8e15-abe8a485c0d2.png)

New code screenshot:
![image](https://user-images.githubusercontent.com/3453282/43674056-258c5be0-97d6-11e8-90f8-99b218346633.png)

Both taken with --anchors argument given to debug.py.