### PR TITLE
Refactor generators

### DIFF
--- a/keras_retinanet/losses.py
+++ b/keras_retinanet/losses.py
@@ -90,8 +90,8 @@ def smooth_l1(sigma=3.0):
         """
         # separate target and state
         regression        = y_pred
-        regression_target = y_true[:, :, :4]
-        anchor_state      = y_true[:, :, 4]
+        regression_target = y_true[:, :, :-1]
+        anchor_state      = y_true[:, :, -1]
 
         # filter out "ignore" anchors
         indices           = backend.where(keras.backend.equal(anchor_state, 1))

--- a/keras_retinanet/models/retinanet.py
+++ b/keras_retinanet/models/retinanet.py
@@ -78,10 +78,11 @@ def default_classification_model(
     return keras.models.Model(inputs=inputs, outputs=outputs, name=name)
 
 
-def default_regression_model(num_anchors, pyramid_feature_size=256, regression_feature_size=256, name='regression_submodel'):
+def default_regression_model(num_values, num_anchors, pyramid_feature_size=256, regression_feature_size=256, name='regression_submodel'):
     """ Creates the default regression submodel.
 
     Args
+        num_values              : Number of values to regress.
         num_anchors             : Number of anchors to regress for each feature level.
         pyramid_feature_size    : The number of filters to expect from the feature pyramid levels.
         regression_feature_size : The number of filters to use in the layers in the regression submodel.
@@ -114,10 +115,10 @@ def default_regression_model(num_anchors, pyramid_feature_size=256, regression_f
             **options
         )(outputs)
 
-    outputs = keras.layers.Conv2D(num_anchors * 4, name='pyramid_regression', **options)(outputs)
+    outputs = keras.layers.Conv2D(num_anchors * num_values, name='pyramid_regression', **options)(outputs)
     if keras.backend.image_data_format() == 'channels_first':
         outputs = keras.layers.Permute((2, 3, 1), name='pyramid_regression_permute')(outputs)
-    outputs = keras.layers.Reshape((-1, 4), name='pyramid_regression_reshape')(outputs)
+    outputs = keras.layers.Reshape((-1, num_values), name='pyramid_regression_reshape')(outputs)
 
     return keras.models.Model(inputs=inputs, outputs=outputs, name=name)
 
@@ -173,7 +174,7 @@ def default_submodels(num_classes, num_anchors):
         A list of tuple, where the first element is the name of the submodel and the second element is the submodel itself.
     """
     return [
-        ('regression', default_regression_model(num_anchors)),
+        ('regression', default_regression_model(4, num_anchors)),
         ('classification', default_classification_model(num_classes, num_anchors))
     ]
 

--- a/keras_retinanet/preprocessing/coco.py
+++ b/keras_retinanet/preprocessing/coco.py
@@ -119,7 +119,7 @@ class CocoGenerator(Generator):
         """
         # get ground truth annotations
         annotations_ids = self.coco.getAnnIds(imgIds=self.image_ids[image_index], iscrowd=False)
-        annotations     = np.zeros((0, 5))
+        annotations     = {'labels': np.empty((0,)), 'bboxes': np.empty((0, 4))}
 
         # some images appear to miss annotations (like image with id 257034)
         if len(annotations_ids) == 0:
@@ -132,13 +132,12 @@ class CocoGenerator(Generator):
             if a['bbox'][2] < 1 or a['bbox'][3] < 1:
                 continue
 
-            annotation        = np.zeros((1, 5))
-            annotation[0, :4] = a['bbox']
-            annotation[0, 4]  = self.coco_label_to_label(a['category_id'])
-            annotations       = np.append(annotations, annotation, axis=0)
-
-        # transform from [x, y, w, h] to [x1, y1, x2, y2]
-        annotations[:, 2] = annotations[:, 0] + annotations[:, 2]
-        annotations[:, 3] = annotations[:, 1] + annotations[:, 3]
+            annotations['labels'] = np.concatenate([annotations['labels'], [self.coco_label_to_label(a['category_id'])]], axis=0)
+            annotations['bboxes'] = np.concatenate([annotations['bboxes'], [[
+                a['bbox'][0],
+                a['bbox'][1],
+                a['bbox'][0] + a['bbox'][2],
+                a['bbox'][1] + a['bbox'][3],
+            ]]], axis=0)
 
         return annotations

--- a/keras_retinanet/preprocessing/csv_generator.py
+++ b/keras_retinanet/preprocessing/csv_generator.py
@@ -199,16 +199,16 @@ class CSVGenerator(Generator):
     def load_annotations(self, image_index):
         """ Load annotations for an image_index.
         """
-        path   = self.image_names[image_index]
-        annots = self.image_data[path]
-        boxes  = np.zeros((len(annots), 5))
+        path        = self.image_names[image_index]
+        annotations = {'labels': np.empty((0,)), 'bboxes': np.empty((0, 4))}
 
-        for idx, annot in enumerate(annots):
-            class_name = annot['class']
-            boxes[idx, 0] = float(annot['x1'])
-            boxes[idx, 1] = float(annot['y1'])
-            boxes[idx, 2] = float(annot['x2'])
-            boxes[idx, 3] = float(annot['y2'])
-            boxes[idx, 4] = self.name_to_label(class_name)
+        for idx, annot in enumerate(self.image_data[path]):
+            annotations['labels'] = np.concatenate((annotations['labels'], [self.name_to_label(annot['class'])]))
+            annotations['bboxes'] = np.concatenate((annotations['bboxes'], [[
+                float(annot['x1']),
+                float(annot['y1']),
+                float(annot['x2']),
+                float(annot['y2']),
+            ]]))
 
-        return boxes
+        return annotations

--- a/keras_retinanet/preprocessing/generator.py
+++ b/keras_retinanet/preprocessing/generator.py
@@ -164,13 +164,16 @@ class Generator(object):
         """
         return [self.load_image(image_index) for image_index in group]
 
-    def random_transform_group_entry(self, image, annotations):
+    def random_transform_group_entry(self, image, annotations, transform=None):
         """ Randomly transforms image and annotation.
         """
         # randomly transform both image and annotations
-        if self.transform_generator:
-            transform = adjust_transform_for_image(next(self.transform_generator), image, self.transform_parameters.relative_translation)
-            image     = apply_transform(transform, image, self.transform_parameters)
+        if transform or self.transform_generator:
+            if transform is None:
+                transform = adjust_transform_for_image(next(self.transform_generator), image, self.transform_parameters.relative_translation)
+
+            # apply transformation to image
+            image = apply_transform(transform, image, self.transform_parameters)
 
             # Transform the bounding boxes in the annotations.
             annotations['bboxes'] = annotations['bboxes'].copy()

--- a/keras_retinanet/preprocessing/generator.py
+++ b/keras_retinanet/preprocessing/generator.py
@@ -261,14 +261,14 @@ class Generator(object):
         max_shape = tuple(max(image.shape[x] for image in image_group) for x in range(3))
         anchors   = self.generate_anchors(max_shape)
 
-        labels_batch, regression_batch = self.compute_anchor_targets(
+        batches = self.compute_anchor_targets(
             anchors,
             image_group,
             annotations_group,
             self.num_classes()
         )
 
-        return [regression_batch, labels_batch]
+        return list(batches)
 
     def compute_input_output(self, group):
         """ Compute inputs and target outputs for the network.

--- a/keras_retinanet/preprocessing/kitti.py
+++ b/keras_retinanet/preprocessing/kitti.py
@@ -139,13 +139,14 @@ class KittiGenerator(Generator):
     def load_annotations(self, image_index):
         """ Load annotations for an image_index.
         """
-        annotations = self.image_data[image_index]
+        image_data = self.image_data[image_index]
+        annotations = {'labels': np.empty((len(image_data),)), 'bboxes': np.empty((len(image_data), 4))}
 
-        boxes = np.zeros((len(annotations), 5))
-        for idx, ann in enumerate(annotations):
-            boxes[idx, 0] = float(ann['x1'])
-            boxes[idx, 1] = float(ann['y1'])
-            boxes[idx, 2] = float(ann['x2'])
-            boxes[idx, 3] = float(ann['y2'])
-            boxes[idx, 4] = int(ann['cls_id'])
-        return boxes
+        for idx, ann in enumerate(image_data):
+            annotations['bboxes'][idx, 0] = float(ann['x1'])
+            annotations['bboxes'][idx, 1] = float(ann['y1'])
+            annotations['bboxes'][idx, 2] = float(ann['x2'])
+            annotations['bboxes'][idx, 3] = float(ann['y2'])
+            annotations['labels'][idx] = int(ann['cls_id'])
+
+        return annotations

--- a/keras_retinanet/preprocessing/open_images.py
+++ b/keras_retinanet/preprocessing/open_images.py
@@ -348,7 +348,7 @@ class OpenImagesGenerator(Generator):
         labels = image_annotations['boxes']
         height, width = image_annotations['h'], image_annotations['w']
 
-        boxes = np.zeros((len(labels), 5))
+        annotations = {'labels': np.empty((len(labels),)), 'bboxes': np.empty((len(labels), 4))}
         for idx, ann in enumerate(labels):
             cls_id = ann['cls_id']
             x1 = ann['x1'] * width
@@ -356,10 +356,10 @@ class OpenImagesGenerator(Generator):
             y1 = ann['y1'] * height
             y2 = ann['y2'] * height
 
-            boxes[idx, 0] = x1
-            boxes[idx, 1] = y1
-            boxes[idx, 2] = x2
-            boxes[idx, 3] = y2
-            boxes[idx, 4] = cls_id
+            annotations['bboxes'][idx, 0] = x1
+            annotations['bboxes'][idx, 1] = y1
+            annotations['bboxes'][idx, 2] = x2
+            annotations['bboxes'][idx, 3] = y2
+            annotations['labels'][idx, 4] = cls_id
 
-        return boxes
+        return annotations

--- a/keras_retinanet/utils/anchors.py
+++ b/keras_retinanet/utils/anchors.py
@@ -107,7 +107,7 @@ def anchor_targets_bbox(
             anchors_centers = np.vstack([(anchors[:, 0] + anchors[:, 2]) / 2, (anchors[:, 1] + anchors[:, 3]) / 2]).T
             indices = np.logical_or(anchors_centers[:, 0] >= image.shape[1], anchors_centers[:, 1] >= image.shape[0])
 
-            labels_batch[index, indices, -1]     = - 1
+            labels_batch[index, indices, -1]     = -1
             regression_batch[index, indices, -1] = -1
 
     return labels_batch, regression_batch

--- a/keras_retinanet/utils/anchors.py
+++ b/keras_retinanet/utils/anchors.py
@@ -75,7 +75,6 @@ def anchor_targets_bbox(
         regression_batch: batch that contains bounding-box regression targets for an image & anchor states (np.array of shape (batch_size, N, 4 + 1),
                       where N is the number of anchors for an image, the first 4 columns define regression targets for (x1, y1, x2, y2) and the
                       last column defines anchor states (-1 for ignore, 0 for bg, 1 for fg).
-        annotations_batch: annotations per anchor (np.array of shape (batch_size, N, annotations.shape[1]), where N is the number of anchors for an image)
     """
 
     assert (len(image_group) == len(annotations_group)), "The length of the images and annotations need to be equal."
@@ -85,13 +84,12 @@ def anchor_targets_bbox(
 
     regression_batch  = np.zeros((batch_size, anchors.shape[0], 4 + 1), dtype=keras.backend.floatx())
     labels_batch      = np.zeros((batch_size, anchors.shape[0], num_classes + 1), dtype=keras.backend.floatx())
-    annotations_batch = np.zeros((batch_size, anchors.shape[0], annotations_group[0].shape[1]), dtype=keras.backend.floatx())
 
     # compute labels and regression targets
     for index, (image, annotations) in enumerate(zip(image_group, annotations_group)):
-        if annotations.shape[0]:
+        if annotations['bboxes'].shape[0]:
             # obtain indices of gt annotations with the greatest overlap
-            positive_indices, ignore_indices, argmax_overlaps_inds = compute_gt_annotations(anchors, annotations, negative_overlap, positive_overlap)
+            positive_indices, ignore_indices, argmax_overlaps_inds = compute_gt_annotations(anchors, annotations['bboxes'], negative_overlap, positive_overlap)
 
             labels_batch[index, ignore_indices, -1]       = -1
             labels_batch[index, positive_indices, -1]     = 1
@@ -99,14 +97,10 @@ def anchor_targets_bbox(
             regression_batch[index, ignore_indices, -1]   = -1
             regression_batch[index, positive_indices, -1] = 1
 
-            # compute box regression targets
-            annotations = annotations[argmax_overlaps_inds]
-            annotations_batch[index, ...] = annotations
-
             # compute target class labels
-            labels_batch[index, positive_indices, annotations[positive_indices, 4].astype(int)] = 1
+            labels_batch[index, positive_indices, annotations['labels'][argmax_overlaps_inds[positive_indices]].astype(int)] = 1
 
-            regression_batch[index, :, :-1] = bbox_transform(anchors, annotations)
+            regression_batch[index, :, :-1] = bbox_transform(anchors, annotations['bboxes'][argmax_overlaps_inds, :])
 
         # ignore annotations outside of image
         if image.shape:
@@ -116,7 +110,7 @@ def anchor_targets_bbox(
             labels_batch[index, indices, -1]     = - 1
             regression_batch[index, indices, -1] = -1
 
-    return labels_batch, regression_batch, annotations_batch
+    return labels_batch, regression_batch
 
 
 def compute_gt_annotations(

--- a/keras_retinanet/utils/anchors.py
+++ b/keras_retinanet/utils/anchors.py
@@ -77,8 +77,11 @@ def anchor_targets_bbox(
                       last column defines anchor states (-1 for ignore, 0 for bg, 1 for fg).
     """
 
-    assert (len(image_group) == len(annotations_group)), "The length of the images and annotations need to be equal."
-    assert (len(annotations_group) > 0), "No data received to compute anchor targets for."
+    assert(len(image_group) == len(annotations_group)), "The length of the images and annotations need to be equal."
+    assert(len(annotations_group) > 0), "No data received to compute anchor targets for."
+    for annotations in annotations_group:
+        assert('bboxes' in annotations), "Annotations should contain bboxes."
+        assert('labels' in annotations), "Annotations should contain labels."
 
     batch_size = len(image_group)
 
@@ -110,7 +113,7 @@ def anchor_targets_bbox(
             labels_batch[index, indices, -1]     = -1
             regression_batch[index, indices, -1] = -1
 
-    return labels_batch, regression_batch
+    return regression_batch, labels_batch
 
 
 def compute_gt_annotations(

--- a/keras_retinanet/utils/eval.py
+++ b/keras_retinanet/utils/eval.py
@@ -135,7 +135,7 @@ def _get_annotations(generator):
 
         # copy detections to all_annotations
         for label in range(generator.num_classes()):
-            all_annotations[i][label] = annotations[annotations[:, 4] == label, :4].copy()
+            all_annotations[i][label] = annotations['bboxes'][annotations['labels'] == label, :].copy()
 
         print('{}/{}'.format(i + 1, generator.size()), end='\r')
 

--- a/keras_retinanet/utils/visualization.py
+++ b/keras_retinanet/utils/visualization.py
@@ -87,14 +87,20 @@ def draw_annotations(image, annotations, color=(0, 255, 0), label_to_name=None):
 
     # Arguments
         image         : The image to draw on.
-        annotations   : A [N, 5] matrix (x1, y1, x2, y2, label).
+        annotations   : A [N, 5] matrix (x1, y1, x2, y2, label) or dictionary containing bboxes (shaped [N, 4]) and labels (shaped [N]).
         color         : The color of the boxes. By default the color from keras_retinanet.utils.colors.label_color will be used.
         label_to_name : (optional) Functor for mapping a label to a name.
     """
-    for a in annotations:
-        label   = a[4]
+    if isinstance(annotations, np.ndarray):
+        annotations = {'bboxes': annotations[:, :4], 'labels': annotations[:, 4]}
+
+    assert('bboxes' in annotations)
+    assert('labels' in annotations)
+    assert(annotations['bboxes'].shape[0] == annotations['labels'].shape[0])
+
+    for i in range(annotations['bboxes'].shape[0]):
+        label   = annotations['labels'][i]
         c       = color if color is not None else label_color(label)
         caption = '{}'.format(label_to_name(label) if label_to_name else label)
-        draw_caption(image, a, caption)
-
-        draw_box(image, a, color=c)
+        draw_caption(image, annotations['bboxes'][i], caption)
+        draw_box(image, annotations['bboxes'][i], color=c)

--- a/tests/layers/test_filter_detections.py
+++ b/tests/layers/test_filter_detections.py
@@ -30,13 +30,13 @@ class TestFilterDetections(object):
             [0, 0, 10, 10],
             [0, 0, 10, 10],  # this will be suppressed
         ]], dtype=keras.backend.floatx())
-        boxes = keras.backend.variable(boxes)
+        boxes = keras.backend.constant(boxes)
 
         classification = np.array([[
             [0, 0.9],  # this will be suppressed
             [0, 1],
         ]], dtype=keras.backend.floatx())
-        classification = keras.backend.variable(classification)
+        classification = keras.backend.constant(classification)
 
         # compute output
         actual_boxes, actual_scores, actual_labels = filter_detections_layer.call([boxes, classification])
@@ -68,13 +68,13 @@ class TestFilterDetections(object):
             [0, 0, 10, 10],
             [0, 0, 10, 10],  # this will be suppressed
         ]], dtype=keras.backend.floatx())
-        boxes = keras.backend.variable(boxes)
+        boxes = keras.backend.constant(boxes)
 
         classification = np.array([[
             [0, 0.9],  # this will be suppressed
             [0, 1],
         ]], dtype=keras.backend.floatx())
-        classification = keras.backend.variable(classification)
+        classification = keras.backend.constant(classification)
 
         other = []
         other.append(np.array([[
@@ -85,7 +85,7 @@ class TestFilterDetections(object):
             5678,  # this will be suppressed
             1234,
         ]], dtype=keras.backend.floatx()))
-        other = [keras.backend.variable(o) for o in other]
+        other = [keras.backend.constant(o) for o in other]
 
         # compute output
         actual = filter_detections_layer.call([boxes, classification] + other)
@@ -133,7 +133,7 @@ class TestFilterDetections(object):
                 [100, 100, 150, 150],  # this will be suppressed
             ],
         ], dtype=keras.backend.floatx())
-        boxes = keras.backend.variable(boxes)
+        boxes = keras.backend.constant(boxes)
 
         classification = np.array([
             [
@@ -145,7 +145,7 @@ class TestFilterDetections(object):
                 [0.9, 0],  # this will be suppressed
             ],
         ], dtype=keras.backend.floatx())
-        classification = keras.backend.variable(classification)
+        classification = keras.backend.constant(classification)
 
         # compute output
         actual_boxes, actual_scores, actual_labels = filter_detections_layer.call([boxes, classification])


### PR DESCRIPTION
This PR refactors the generators so that the returned type of `load_annotations` is a dictionary. This allows for more customization in what data needs to be handled by the generator. Previously, all data would have to be transformed to fit together with the boxes / labels. With this PR, every piece is it's own key/value pair.

The minimum requirement for retinanet is to have `bboxes` and `labels` annotations.