### PR TITLE
Add a --config option to the retinanet-convert-model command

### DIFF
--- a/keras_retinanet/bin/convert_model.py
+++ b/keras_retinanet/bin/convert_model.py
@@ -33,6 +33,7 @@ if __name__ == "__main__" and __package__ is None:
 from .. import models
 from ..utils.config import read_config_file, parse_anchor_parameters
 
+
 def get_session():
     """ Construct a modified tf session.
     """

--- a/keras_retinanet/bin/convert_model.py
+++ b/keras_retinanet/bin/convert_model.py
@@ -31,7 +31,7 @@ if __name__ == "__main__" and __package__ is None:
 
 # Change these to absolute imports if you copy this script outside the keras_retinanet package.
 from .. import models
-
+from ..utils.config import read_config_file, parse_anchor_parameters
 
 def get_session():
     """ Construct a modified tf session.
@@ -49,6 +49,7 @@ def parse_args(args):
     parser.add_argument('--backbone', help='The backbone of the model to convert.', default='resnet50')
     parser.add_argument('--no-nms', help='Disables non maximum suppression.', dest='nms', action='store_false')
     parser.add_argument('--no-class-specific-filter', help='Disables class specific filtering.', dest='class_specific_filter', action='store_false')
+    parser.add_argument('--config', help='Path to a configuration parameters .ini file.')
 
     return parser.parse_args(args)
 
@@ -62,6 +63,13 @@ def main(args=None):
     # Set modified tf session to avoid using the GPUs
     keras.backend.tensorflow_backend.set_session(get_session())
 
+    # optionally load config parameters
+    anchor_parameters = None
+    if args.config:
+        args.config = read_config_file(args.config)
+        if 'anchor_parameters' in args.config:
+            anchor_parameters = parse_anchor_parameters(args.config)
+
     # load the model
     model = models.load_model(args.model_in, backbone_name=args.backbone)
 
@@ -69,7 +77,7 @@ def main(args=None):
     models.check_training_model(model)
 
     # convert the model
-    model = models.convert_model(model, nms=args.nms, class_specific_filter=args.class_specific_filter)
+    model = models.convert_model(model, nms=args.nms, class_specific_filter=args.class_specific_filter, anchor_params=anchor_parameters)
 
     # save model
     model.save(args.model_out)


### PR DESCRIPTION
If the model is trained with custom anchors read from a config.ini file then the conversion should also be run with the same configuration file to ensure the number of anchors is correct in the converted model.