### PR TITLE
Improvement of workflow to prepare your own dataset in CSV format

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,16 @@ cat,1
 bird,2
 ```
 
+
+### Convert annotation format to CSV
+Here is a sample workflow to prepare your own datase.
+
+1. Correct images for training
+2. Create annotations of images using [LabelImg](https://github.com/tzutalin/labelImg) with Pascal VOC xml format
+3. Convert annotation format from Pascal VOC xml format to CSV format using [akchan/conv_pascal_to_csv: Training data converter for fizyr/keras-retinanet](https://github.com/akchan/conv_pascal_to_csv)
+4. Start to train your model!
+
+
 ## Debugging
 Creating your own dataset does not always work out of the box. There is a [`debug.py`](https://github.com/fizyr/keras-retinanet/blob/master/keras_retinanet/bin/debug.py) tool to help find the most common mistakes.
 


### PR DESCRIPTION
# Summary
This pull request will add an introduction of a sample workflow to prepare own dataset in CSV.

# Problem
Thank your for your great effort in `keras-retinanet`.

The CSV format included in `keras-retinanet` is very nice way to prepare own dataset for training. I think many people use a tool to annotate images, but couldn't find a tool that can create an annotation file in CSV format used in `keras-retinanet` directly.

# Solution
So, I create a format converting script `conv_pascal_to_csv.rb` and pull request here to introduce this workflow.

# Discussion point of this pull-req
Modification of README.md in this pull-req will introduce a specific tool. I'm worried if someone thinks that this pull-req isn't appropriate in this repository.

