### PR TITLE
Avoid importing numpy in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,38 @@
 import setuptools
 from setuptools.extension import Extension
+from distutils.command.build_ext import build_ext as DistUtilsBuildExt
 
-class custom_wrapper(object):
-    def __new__(cls, *args, **kwargs):
-        from setuptools.command.build_ext import build_ext
-        class custom_build_ext(build_ext, object):
-            def run(self):
-                import numpy as np
-                self.include_dirs.append(np.get_include())
-                build_ext.run(self)
-        return custom_build_ext(*args, **kwargs)
+
+class BuildExtension(setuptools.Command):
+    description     = DistUtilsBuildExt.description
+    user_options    = DistUtilsBuildExt.user_options
+    boolean_options = DistUtilsBuildExt.boolean_options
+    help_options    = DistUtilsBuildExt.help_options
+
+    def __init__(self, *args, **kwargs):
+        from setuptools.command.build_ext import build_ext as SetupToolsBuildExt
+
+        # Bypass __setatrr__ to avoid infinite recursion.
+        self.__dict__['_command'] = SetupToolsBuildExt(*args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._command, name)
+
+    def __setattr__(self, name, value):
+        setattr(self._command, name, value)
+
+    def initialize_options(self, *args, **kwargs):
+        return self._command.initialize_options(*args, **kwargs)
+
+    def finalize_options(self, *args, **kwargs):
+        ret = self._command.finalize_options(*args, **kwargs)
+        import numpy
+        self.include_dirs.append(numpy.get_include())
+        return ret
+
+    def run(self, *args, **kwargs):
+        return self._command.run(*args, **kwargs)
+
 
 extensions = [
     Extension(
@@ -17,6 +40,7 @@ extensions = [
         ['keras_retinanet/utils/compute_overlap.pyx']
     ),
 ]
+
 
 setuptools.setup(
     name             = 'keras-retinanet',
@@ -27,7 +51,7 @@ setuptools.setup(
     author_email     = 'h.gaiser@fizyr.com',
     maintainer       = 'Hans Gaiser',
     maintainer_email = 'h.gaiser@fizyr.com',
-    cmdclass         = {'build_ext': custom_wrapper},
+    cmdclass         = {'build_ext': BuildExtension},
     packages         = setuptools.find_packages(),
     install_requires = ['keras', 'keras-resnet', 'six', 'scipy', 'cython', 'Pillow', 'opencv-python', 'progressbar2'],
     entry_points     = {

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,20 @@
 import setuptools
 from setuptools.extension import Extension
-import numpy as np
+
+class custom_wrapper(object):
+    def __new__(cls, *args, **kwargs):
+        from setuptools.command.build_ext import build_ext
+        class custom_build_ext(build_ext, object):
+            def run(self):
+                import numpy as np
+                self.include_dirs.append(np.get_include())
+                build_ext.run(self)
+        return custom_build_ext(*args, **kwargs)
 
 extensions = [
     Extension(
         'keras_retinanet.utils.compute_overlap',
-        ['keras_retinanet/utils/compute_overlap.pyx'],
-        include_dirs=[np.get_include()]
+        ['keras_retinanet/utils/compute_overlap.pyx']
     ),
 ]
 
@@ -19,6 +27,7 @@ setuptools.setup(
     author_email     = 'h.gaiser@fizyr.com',
     maintainer       = 'Hans Gaiser',
     maintainer_email = 'h.gaiser@fizyr.com',
+    cmdclass         = {'build_ext': custom_wrapper},
     packages         = setuptools.find_packages(),
     install_requires = ['keras', 'keras-resnet', 'six', 'scipy', 'cython', 'Pillow', 'opencv-python', 'progressbar2'],
     entry_points     = {
@@ -30,5 +39,5 @@ setuptools.setup(
         ],
     },
     ext_modules    = extensions,
-    setup_requires = ["cython>=0.28"]
+    setup_requires = ["cython>=0.28", "numpy>=1.14.0"]
 )


### PR DESCRIPTION
With the current setup.py file, keras-retinanet cannot be installed if numpy is not present.
With the updated version, numpy is specified as a dependency of keras-retinanet and is installed on the fly if needed.