### PR TITLE
keras sequence methods for generator

### DIFF
--- a/keras_retinanet/bin/train.py
+++ b/keras_retinanet/bin/train.py
@@ -409,6 +409,11 @@ def parse_args(args):
     parser.add_argument('--config',           help='Path to a configuration parameters .ini file.')
     parser.add_argument('--weighted-average', help='Compute the mAP using the weighted average of precisions among classes.', action='store_true')
 
+    #Fit generator arguments
+    parser.add_argument('--multiprocessing', help='Fit generator mulitprocessing for n worker processes', action='store_true')
+    parser.add_argument('--workers', help='Number of multiprocessing workers', default=1)
+    parser.add_argument('--max_queue_size', help='Queue length for multiprocessing workers in fit generator', default=10)
+    
     return check_args(parser.parse_args(args))
 
 
@@ -486,6 +491,9 @@ def main(args=None):
         epochs=args.epochs,
         verbose=1,
         callbacks=callbacks,
+        workers=args.workers,
+        use_multiprocessing=args.multiprocessing,
+        max_queue_size=args.max_queue_size
     )
 
 

--- a/tests/preprocessing/test_generator.py
+++ b/tests/preprocessing/test_generator.py
@@ -262,7 +262,7 @@ class TestFilterAnnotations(object):
         simple_generator = SimpleGenerator(input_bboxes_group, input_labels_group, image=input_image, num_classes=6)
         # expect a UserWarning
         with pytest.warns(UserWarning):
-            _, [_, labels_batch] = simple_generator.next()
+            _, [_, labels_batch] = simple_generator.__getitem__(0)
 
         # test that only object with class 5 is present in labels_batch
         labels = np.unique(np.argmax(labels_batch == 5, axis=2))


### PR DESCRIPTION
The goal of this PR is to introduce the keras sequence method (https://keras.io/models/sequential/) to the default generator class.

Goals 

1. Improve parallelization and thread-safe generators. Keras docs state:

"The use of keras.utils.Sequence guarantees the ordering and guarantees the single use of every input per epoch when using use_multiprocessing=True."

2. Implemented a __getitem__ and __len__ method.

3. Remove threading and locks.

4. Move group shuffling to explicit on_epoch_end method

5. Added command line arguments for the fit_generator method.

I cloned the master, built a new conda env, and ran the generator and generator csv tests. 

*Potential Drawbacks*

A number of windows users have complained about multiprocessing in keras. I found that multiprocessing was only useful when

1. Generator performs alot of processing. This could happen when files are very large and reading is the bottleneck. Or when the user creates a custom generator method (as I've done in my fork).

2. When there is sufficient memory to fill the queue. 

My production environment:

I am running linux on a large multi-node cluster, feeding in > 20,000 images during training in batches of 6. I found a huge performance boosts from using the sequence method and multiprocessing, but the overhead is probably too much for the csv generator method in most cases.
