### PR TITLE
Fixed shuffling at end of epoch when shuffling is False

### DIFF
--- a/keras_retinanet/preprocessing/generator.py
+++ b/keras_retinanet/preprocessing/generator.py
@@ -88,7 +88,8 @@ class Generator(keras.utils.Sequence):
             self.on_epoch_end()
 
     def on_epoch_end(self):
-        random.shuffle(self.groups)
+        if self.shuffle_groups:
+            random.shuffle(self.groups)
 
     def size(self):
         """ Size of the dataset.


### PR DESCRIPTION
Fixed this small bug that was introduced with https://github.com/fizyr/keras-retinanet/pull/824
It's currently shuffling every epoch, with this patch, it takes the shuffle_groups parameter into account again.