### PR TITLE
Add validation data to training, and return Keras History object.

### DIFF
--- a/keras_retinanet/bin/train.py
+++ b/keras_retinanet/bin/train.py
@@ -493,7 +493,7 @@ def main(args=None):
         use_multiprocessing = False
 
     # start training
-    training_model.fit_generator(
+    return training_model.fit_generator(
         generator=train_generator,
         steps_per_epoch=args.steps,
         epochs=args.epochs,
@@ -501,7 +501,8 @@ def main(args=None):
         callbacks=callbacks,
         workers=args.workers,
         use_multiprocessing=use_multiprocessing,
-        max_queue_size=args.max_queue_size
+        max_queue_size=args.max_queue_size,
+	validation_data=validation_generator
     )
 
 

--- a/keras_retinanet/bin/train.py
+++ b/keras_retinanet/bin/train.py
@@ -502,7 +502,7 @@ def main(args=None):
         workers=args.workers,
         use_multiprocessing=use_multiprocessing,
         max_queue_size=args.max_queue_size,
-	validation_data=validation_generator
+        validation_data=validation_generator
     )
 
 

--- a/keras_retinanet/bin/train.py
+++ b/keras_retinanet/bin/train.py
@@ -410,6 +410,7 @@ def parse_args(args):
     parser.add_argument('--image-max-side',   help='Rescale the image if the largest side is larger than max_side.', type=int, default=1333)
     parser.add_argument('--config',           help='Path to a configuration parameters .ini file.')
     parser.add_argument('--weighted-average', help='Compute the mAP using the weighted average of precisions among classes.', action='store_true')
+    parser.add_argument('--compute-val-loss', help='Compute validation loss during training', dest='compute_val_loss', action='store_false')
 
     # Fit generator arguments
     parser.add_argument('--workers', help='Number of multiprocessing workers. To disable multiprocessing, set workers to 0', type=int, default=1)
@@ -491,6 +492,9 @@ def main(args=None):
         use_multiprocessing = True
     else:
         use_multiprocessing = False
+
+    if not args.compute_val_loss:
+        validation_generator = None
 
     # start training
     return training_model.fit_generator(


### PR DESCRIPTION
The reason for this addition is to take into account the validation generator during training (for validation loss, etc.), and return the History object from Keras for logging purposes instead of just ignoring it. 

Please have a look at [History Callback](https://keras.io/callbacks/#history) for more information on the usefulness of this addition.

Best,
Daniyal