### PR TITLE
Anchors grow dynamically with smaller strides

### DIFF
--- a/keras_retinanet/utils/anchors.py
+++ b/keras_retinanet/utils/anchors.py
@@ -188,7 +188,7 @@ def guess_shapes(image_shape, strides):
 
     Args
          image_shape: The shape of the image.
-         pyramid_levels: A list of what strides are used.
+         strides: A list of what strides are used.
 
     Returns
         A list of image shapes at each pyramid level based on the stride size

--- a/keras_retinanet/utils/anchors.py
+++ b/keras_retinanet/utils/anchors.py
@@ -183,7 +183,7 @@ def make_shapes_callback(model):
     return get_shapes
 
 
-def guess_shapes(image_shape, pyramid_levels):
+def guess_shapes(image_shape, strides):
     """Guess shapes based on pyramid levels.
 
     Args
@@ -194,7 +194,7 @@ def guess_shapes(image_shape, pyramid_levels):
         A list of image shapes at each pyramid level.
     """
     image_shape = np.array(image_shape[:2])
-    image_shapes = [(image_shape + 2 ** x - 1) // (2 ** x) for x in pyramid_levels]
+    image_shapes = [(image_shape + stride - 1) // stride for stride in strides]
     return image_shapes
 
 
@@ -224,7 +224,7 @@ def anchors_for_shape(
 
     if shapes_callback is None:
         shapes_callback = guess_shapes
-    image_shapes = shapes_callback(image_shape, pyramid_levels)
+    image_shapes = shapes_callback(image_shape, anchor_params.strides)
 
     # compute anchors over all pyramid levels
     all_anchors = np.zeros((0, 4))

--- a/keras_retinanet/utils/anchors.py
+++ b/keras_retinanet/utils/anchors.py
@@ -184,14 +184,14 @@ def make_shapes_callback(model):
 
 
 def guess_shapes(image_shape, strides):
-    """Guess shapes based on pyramid levels.
+    """Guess shapes based on the strides.
 
     Args
          image_shape: The shape of the image.
-         pyramid_levels: A list of what pyramid levels are used.
+         pyramid_levels: A list of what strides are used.
 
     Returns
-        A list of image shapes at each pyramid level.
+        A list of image shapes at each pyramid level based on the stride size
     """
     image_shape = np.array(image_shape[:2])
     image_shapes = [(image_shape + stride - 1) // stride for stride in strides]


### PR DESCRIPTION
I'd like to detect smaller objects, so I made a bit of research on how the anchor parameter settings work in your repository. Since small objects might appear almost anywhere in the image, I'd like to place the anchorboxes tight and decrease the default anchorbox.strides parameter (from [8, 16, 32, 64, 128]). 

Looking at shift() and guess_shapes() functions under utils.anchorbox module, when I changed the default strides to [4, 8, 16, 32, 64] (halving the default), the anchorboxes covered only the top-left quarter of the image. This tiny change ensures the anchors cover the entire image, not less and not more, whatever strides are given.

Sorry for making it in 5 commits, I messed things up. ^^'