### PR TITLE
Check validity of the config to avoid silent errors.

### DIFF
--- a/keras_retinanet/utils/config.py
+++ b/keras_retinanet/utils/config.py
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import os
 import configparser
 import numpy as np
 import keras

--- a/keras_retinanet/utils/config.py
+++ b/keras_retinanet/utils/config.py
@@ -23,15 +23,18 @@ from ..utils.anchors import AnchorParameters
 
 def read_config_file(config_path):
     config = configparser.ConfigParser()
-    config.read(config_path)
 
-    assert os.path.isfile(config_path), "Could not find {}.".format(config_path)
+    with open(config_path, 'r') as file:
+        config.read_file(file)
 
     assert 'anchor_parameters' in config, \
         "Malformed config file. Verify that it contains the anchor_parameters section."
 
-    assert {'sizes', 'strides', 'ratios', 'scales'} <= set(config['anchor_parameters']), \
-        "Malformed config file. Verify that it contains the following keys: sizes, strides, ratios and scales."
+    config_keys = set(config['anchor_parameters'])
+    default_keys = set(AnchorParameters.default.__dict__.keys())
+
+    assert config_keys <= default_keys, \
+        "Malformed config file. These keys are not valid: {}".format(config_keys - default_keys)
 
     return config
 

--- a/keras_retinanet/utils/config.py
+++ b/keras_retinanet/utils/config.py
@@ -24,7 +24,7 @@ from ..utils.anchors import AnchorParameters
 def read_config_file(config_path):
     config = configparser.ConfigParser()
     config.read(config_path)
-    
+
     assert os.path.isfile(config_path), "Could not find {}.".format(config_path)
 
     assert 'anchor_parameters' in config, \

--- a/keras_retinanet/utils/config.py
+++ b/keras_retinanet/utils/config.py
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import os
 import configparser
 import numpy as np
 import keras
@@ -23,6 +24,14 @@ from ..utils.anchors import AnchorParameters
 def read_config_file(config_path):
     config = configparser.ConfigParser()
     config.read(config_path)
+    
+    assert os.path.isfile(config_path), "Could not find {}.".format(config_path)
+
+    assert 'anchor_parameters' in config, \
+        "Malformed config file. Verify that it contains the anchor_parameters section."
+
+    assert {'sizes', 'strides', 'ratios', 'scales'} <= set(config['anchor_parameters']), \
+        "Malformed config file. Verify that it contains the following keys: sizes, strides, ratios and scales."
 
     return config
 


### PR DESCRIPTION
The configparser library which is used fails silently when it cannot find the config file and then retinanet continues as normal and uses the default configuration. This PR adds assertions to check that the file exists and isn't malformed.