### PR TITLE
Added functionality to manually cycle through dataset in debug.py

### DIFF
--- a/keras_retinanet/bin/debug.py
+++ b/keras_retinanet/bin/debug.py
@@ -205,13 +205,16 @@ def run(generator, args, anchor_params):
         while True:
             key = cv2.waitKey(1)
             cv2.imshow('Image', image)
-            if key == ord('n'): # press n for next image
+            # press n for next image
+            if key == ord('n'):
                 i += 1
                 break
-            if key == ord('b'): # press b for previous image
+            # press b for previous image    
+            if key == ord('b'):
                 i -= 1
                 break
-            if key == ord('q'): # press q to quit
+            # press q to quit    
+            if key == ord('q'): 
                 return False
     return True
 

--- a/keras_retinanet/bin/debug.py
+++ b/keras_retinanet/bin/debug.py
@@ -201,9 +201,18 @@ def run(generator, args, anchor_params):
                 # result is that annotations without anchors are red, with anchors are green
                 draw_boxes(image, annotations['bboxes'][max_indices[positive_indices], :], (0, 255, 0))
 
-        cv2.imshow('Image', image)
-        if cv2.waitKey() == ord('q'):
-            return False
+        key = cv2.waitKey(1)
+        while True:
+            key = cv2.waitKey(1)
+            cv2.imshow('Image', image)
+            if key == ord('n'): # press n for next image
+                i += 1
+                break
+            if key == ord('b'): # press b for previous image
+                i -= 1
+                break
+            if key == ord('q'): # press q to quit
+                return False
     return True
 
 
@@ -218,6 +227,9 @@ def main(args=None):
 
     # create the generator
     generator = create_generator(args)
+
+    # sorting list of images for cycling through dataset
+    generator.image_names = sorted(generator.image_names)
 
     # optionally load config parameters
     if args.config:

--- a/keras_retinanet/bin/debug.py
+++ b/keras_retinanet/bin/debug.py
@@ -201,8 +201,8 @@ def run(generator, args, anchor_params):
                 # result is that annotations without anchors are red, with anchors are green
                 draw_boxes(image, annotations['bboxes'][max_indices[positive_indices], :], (0, 255, 0))
 
-        key = cv2.waitKey(1)
         cv2.imshow('Image', image)
+        key = cv2.waitKey()
         # note that the right and left keybindings are probably different for windows
         # press right for next image
         if key == 83:

--- a/keras_retinanet/bin/debug.py
+++ b/keras_retinanet/bin/debug.py
@@ -209,12 +209,12 @@ def run(generator, args, anchor_params):
             if key == ord('n'):
                 i += 1
                 break
-            # press b for previous image    
+            # press b for previous image
             if key == ord('b'):
                 i -= 1
                 break
-            # press q to quit    
-            if key == ord('q'): 
+            # press q to quit
+            if key == ord('q'):
                 return False
     return True
 

--- a/keras_retinanet/bin/debug.py
+++ b/keras_retinanet/bin/debug.py
@@ -202,20 +202,17 @@ def run(generator, args, anchor_params):
                 draw_boxes(image, annotations['bboxes'][max_indices[positive_indices], :], (0, 255, 0))
 
         key = cv2.waitKey(1)
-        while True:
-            key = cv2.waitKey(1)
-            cv2.imshow('Image', image)
-            # press n for next image
-            if key == ord('n'):
-                i += 1
-                break
-            # press b for previous image
-            if key == ord('b'):
-                i -= 1
-                break
-            # press q to quit
-            if key == ord('q'):
-                return False
+        cv2.imshow('Image', image)
+        # note that the right and left keybindings are probably different for windows
+        # press right for next image
+        if key == 83:
+            i += 1
+        # press left for previous image
+        if key == 81:
+            i -= 1
+        # press q to quit
+        if key == ord('q'):
+            return False
     return True
 
 
@@ -230,9 +227,6 @@ def main(args=None):
 
     # create the generator
     generator = create_generator(args)
-
-    # sorting list of images for cycling through dataset
-    generator.image_names = sorted(generator.image_names)
 
     # optionally load config parameters
     if args.config:


### PR DESCRIPTION
Hi, this is my first pull request so please bear with me!

I've been working with a custom dataset using keras-retinanet and realised that debug.py doesn't automatically cycle through the images in my dataset since by default there is no argument passed into `cv2.waitKey()`, causing it to default to a value a 0. This means that `cv2.imshow()` remains stuck at a single image.

This was easily remedied by increasing the value from 0 to 1000, to create a one second delay between the images - not sure if this was a bug or if it was intended, but the lack of any comments led me to believe the former.

I also ended up adding a simple way to cycle through your dataset using the 'n' and 'b' keys. This should be pretty easy to change to the arrow keys as well.

However I feel the only issue might be the line where I sort `generator.image_names`, as maybe this might run too slow for very large datasets?

I'm not entirely sure about whether this is a concern with regards to debug.py's runtime, as I only sort the list once. However I hope my "feature" is of some use to you!