### PR TITLE
Fix for multiprocessing arguments in train.py

### DIFF
--- a/keras_retinanet/bin/train.py
+++ b/keras_retinanet/bin/train.py
@@ -414,7 +414,7 @@ def parse_args(args):
 
     # Fit generator arguments
     parser.add_argument('--multiprocessing',  help='Use multiprocessing in fit_generator.', action='store_true')
-    parser.add_argument('--workers',          help='Number of multiprocessing workers.', type=int, default=1)
+    parser.add_argument('--workers',          help='Number of generator workers.', type=int, default=1)
     parser.add_argument('--max-queue-size',   help='Queue length for multiprocessing workers in fit_generator.', type=int, default=10)
 
     return check_args(parser.parse_args(args))

--- a/keras_retinanet/bin/train.py
+++ b/keras_retinanet/bin/train.py
@@ -413,8 +413,9 @@ def parse_args(args):
     parser.add_argument('--compute-val-loss', help='Compute validation loss during training', dest='compute_val_loss', action='store_true')
 
     # Fit generator arguments
-    parser.add_argument('--workers', help='Number of multiprocessing workers. To disable multiprocessing, set workers to 0', type=int, default=1)
-    parser.add_argument('--max-queue-size', help='Queue length for multiprocessing workers in fit generator.', type=int, default=10)
+    parser.add_argument('--multiprocessing',  help='Use multiprocessing in fit_generator.', action='store_true')
+    parser.add_argument('--workers',          help='Number of multiprocessing workers.', type=int, default=1)
+    parser.add_argument('--max-queue-size',   help='Queue length for multiprocessing workers in fit_generator.', type=int, default=10)
 
     return check_args(parser.parse_args(args))
 
@@ -487,12 +488,6 @@ def main(args=None):
         args,
     )
 
-    # Use multiprocessing if workers > 0
-    if args.workers > 0:
-        use_multiprocessing = True
-    else:
-        use_multiprocessing = False
-
     if not args.compute_val_loss:
         validation_generator = None
 
@@ -504,7 +499,7 @@ def main(args=None):
         verbose=1,
         callbacks=callbacks,
         workers=args.workers,
-        use_multiprocessing=use_multiprocessing,
+        use_multiprocessing=args.multiprocessing,
         max_queue_size=args.max_queue_size,
         validation_data=validation_generator
     )


### PR DESCRIPTION
I think there was an inadvertent minor issue introduced with [this commit](https://github.com/fizyr/keras-retinanet/commit/508d877aca442bfdb80d2b7bf1be75e8d60bb48f) that was discussed [here](https://github.com/fizyr/keras-retinanet/pull/824#pullrequestreview-182927546) (click on the ```keras_retinanet/bin/train.py``` bar to expand it to see dialogue). In particular, there is now no way to run fit_generator with workers=1 and use_multiprocessing=False. On the surface, this seems like it shouldn't be an issue. However, the way Keras is implemented, it will have different behavior when workers=1 depending on whether use_mutliprocessing is True or False. Additionally, setting workers=0 will make use_multiprocessing=False, but leads to a different code path than when workers=1 (so that doesn't solve the problem). These differences can be seen by inspecting the Keras source [code](https://github.com/keras-team/keras/blob/master/keras/engine/training_generator.py#L153) and also, the Keras fit_generator documentation mentions how workers=0 is handled differently.

The reason I'm bringing this up is that I noticed slower training time between 0.5.0 and 0.5.1 and narrowed it down to this issue. Using the default settings, fit generator is called with workers=1 and use_multiprocessing=True in 0.5.1 whereas in 0.5.0, use_multiprocessing was False. At least for the model I'm training which is standard ResNet50 backbone using the csv_generator class, it is fastest to train with workers=1 and multiprocessing=False.

I ran a few tests on 0.5.1 with a couple modifications. In all tests, I'm training on a csv dataset with no validation and the following arguments:
```--epochs 3 --steps 1000 --image-min-side 480 --image-max-side 960 --batch-size 4 --random-transform```
The only thing I manipulated in the experiments was the value of ```workers``` and ```use_multiprocessing``` that are used in fit_generator. Training was done on an EC2 P3 machine with 1 GPU and 8 CPUs. Below I report the training time for the first 3 epochs:

use_multiprocessing, workers, epoch 1, epoch 2, epoch 3
False, 0, 535s, 410s, 385s
False, 1, 376s, 250s, 241s  <This should be the default configuration>
True, 1, 400s, 289s, 289s  <This is the default configuration for 0.5.1>
True, 2, 381s, 263s, 237s
True, 4, 395s, 260s, 246s

The time differences are not dramatic, but I have observed similar patterns in other tests I did. I believe they are large enough to warrant this change (even though I agree that having just a --workers argument is more elegant). At least in my tests, you can mostly overcome the issue by setting workers to 2, but that is not the default behavior.