### PR TITLE
Fix 'draw_detections'

### DIFF
--- a/keras_retinanet/utils/eval.py
+++ b/keras_retinanet/utils/eval.py
@@ -103,7 +103,7 @@ def _get_detections(generator, model, score_threshold=0.05, max_detections=100, 
 
         if save_path is not None:
             draw_annotations(raw_image, generator.load_annotations(i), label_to_name=generator.label_to_name)
-            draw_detections(raw_image, image_boxes, image_scores, image_labels, label_to_name=generator.label_to_name)
+            draw_detections(raw_image, image_boxes, image_scores, image_labels, label_to_name=generator.label_to_name, score_threshold=score_threshold)
 
             cv2.imwrite(os.path.join(save_path, '{}.png'.format(i)), raw_image)
 


### PR DESCRIPTION
`predict_on_batch` returns 300 boxes by default (unless specified otherwise), and then these are chopped down by `score_threshold=0.05` and `max_detections=100` by default.

However, when it comes to drawing by `draw_detections` the default `score_threshold` is 0.5 leading in wrong visual estimation.

This PR inserts in the function the correct `score_threshold` specified by the training process.