### PR TITLE
Updated Train.py to fix tensorboard issue

### DIFF
--- a/keras_retinanet/bin/train.py
+++ b/keras_retinanet/bin/train.py
@@ -157,7 +157,7 @@ def create_callbacks(model, training_model, prediction_model, validation_generat
             embeddings_layer_names = None,
             embeddings_metadata    = None
         )
-        callbacks.append(tensorboard_callback)
+        
 
     if args.evaluation and validation_generator:
         if args.dataset_type == 'coco':
@@ -197,6 +197,9 @@ def create_callbacks(model, training_model, prediction_model, validation_generat
         cooldown   = 0,
         min_lr     = 0
     ))
+   
+    if args.tensorboard_dir:
+        callbacks.append(tensorboard_callback)
 
     return callbacks
 


### PR DESCRIPTION
Moving the tensorboard callback to the end of the callback list allows mAP and LR to be updated when the epoch ends. As of right now they are 1 epoch behind in the tensorboard graph.