### PR TITLE
add --no-resize parameter to allow training w/o resizing input images

### DIFF
--- a/keras_retinanet/bin/train.py
+++ b/keras_retinanet/bin/train.py
@@ -215,6 +215,7 @@ def create_generators(args, preprocess_image):
         'config'           : args.config,
         'image_min_side'   : args.image_min_side,
         'image_max_side'   : args.image_max_side,
+        'no_resize'        : args.no_resize,
         'preprocess_image' : preprocess_image,
     }
 
@@ -421,6 +422,7 @@ def parse_args(args):
     parser.add_argument('--random-transform', help='Randomly transform image and annotations.', action='store_true')
     parser.add_argument('--image-min-side',   help='Rescale the image so the smallest side is min_side.', type=int, default=800)
     parser.add_argument('--image-max-side',   help='Rescale the image if the largest side is larger than max_side.', type=int, default=1333)
+    parser.add_argument('--no-resize',        help='Don''t rescale the image.', action='store_true')
     parser.add_argument('--config',           help='Path to a configuration parameters .ini file.')
     parser.add_argument('--weighted-average', help='Compute the mAP using the weighted average of precisions among classes.', action='store_true')
     parser.add_argument('--compute-val-loss', help='Compute validation loss during training', dest='compute_val_loss', action='store_true')

--- a/keras_retinanet/preprocessing/generator.py
+++ b/keras_retinanet/preprocessing/generator.py
@@ -49,6 +49,7 @@ class Generator(keras.utils.Sequence):
         shuffle_groups=True,
         image_min_side=800,
         image_max_side=1333,
+        no_resize=False,
         transform_parameters=None,
         compute_anchor_targets=anchor_targets_bbox,
         compute_shapes=guess_shapes,
@@ -64,6 +65,7 @@ class Generator(keras.utils.Sequence):
             shuffle_groups         : If True, shuffles the groups each epoch.
             image_min_side         : After resizing the minimum side of an image is equal to image_min_side.
             image_max_side         : If after resizing the maximum side is larger than image_max_side, scales down further so that the max side is equal to image_max_side.
+            no_resize              : If True, no image/annotation resizing is performed.
             transform_parameters   : The transform parameters used for data augmentation.
             compute_anchor_targets : Function handler for computing the targets of anchors for an image and its annotations.
             compute_shapes         : Function handler for computing the shapes of the pyramid for a given input.
@@ -76,6 +78,7 @@ class Generator(keras.utils.Sequence):
         self.shuffle_groups         = shuffle_groups
         self.image_min_side         = image_min_side
         self.image_max_side         = image_max_side
+        self.no_resize              = no_resize
         self.transform_parameters   = transform_parameters or TransformParameters()
         self.compute_anchor_targets = compute_anchor_targets
         self.compute_shapes         = compute_shapes
@@ -239,7 +242,10 @@ class Generator(keras.utils.Sequence):
     def resize_image(self, image):
         """ Resize an image using image_min_side and image_max_side.
         """
-        return resize_image(image, min_side=self.image_min_side, max_side=self.image_max_side)
+        if self.no_resize:
+            return image, 1
+        else:
+            return resize_image(image, min_side=self.image_min_side, max_side=self.image_max_side)
 
     def preprocess_group_entry(self, image, annotations):
         """ Preprocess image and its annotations.


### PR DESCRIPTION
Add a parameter `--no-resize` to `train.py`, so that one can train a model without any resizing of the input images.  The mechanism is very simple: the method `resize_image(self, image)` of class `Generator(keras.utils.Sequence)` is modified so that if the `no_resize` parameter is passed when initializing a `generator` object, then `resize_image` always returns a scale of 1, instead of computing it.

```
    def resize_image(self, image):
        """ Resize an image using image_min_side and image_max_side.
        """
        if self.no_resize:
            return image, 1
        else:
            return resize_image(image, min_side=self.image_min_side, max_side=self.image_max_side)
```

Since the change is made in  the `Generator` class, it works for all data generators, since they inherit from this class.