### PR TITLE
fix issue #1113, but only for the COCO generator

### DIFF
--- a/keras_retinanet/preprocessing/coco.py
+++ b/keras_retinanet/preprocessing/coco.py
@@ -40,8 +40,6 @@ class CocoGenerator(Generator):
         self.set_name  = set_name
         self.coco      = COCO(os.path.join(data_dir, 'annotations', 'instances_' + set_name + '.json'))
         self.image_ids = self.coco.getImgIds()
-        self.images    = self.coco.loadImgs(self.image_ids)
-        self.image_names = [image['file_name'] for image in self.images] 
 
         self.load_classes()
 
@@ -116,7 +114,9 @@ class CocoGenerator(Generator):
     def image_path(self, image_index):
         """ Returns the image path for image_index.
         """
-        return os.path.join(self.data_dir, self.image_names[image_index])
+        image_info = self.coco.loadImgs(self.image_ids[image_index])[0]
+        path       = os.path.join(self.data_dir, 'images', self.set_name, image_info['file_name'])
+        return path
 
     def image_aspect_ratio(self, image_index):
         """ Compute the aspect ratio for an image with image_index.
@@ -127,8 +127,7 @@ class CocoGenerator(Generator):
     def load_image(self, image_index):
         """ Load an image at the image_index.
         """
-        image_info = self.coco.loadImgs(self.image_ids[image_index])[0]
-        path       = os.path.join(self.data_dir, 'images', self.set_name, image_info['file_name'])
+        path  = self.image_path(image_index)
         return read_image_bgr(path)
 
     def load_annotations(self, image_index):

--- a/keras_retinanet/preprocessing/coco.py
+++ b/keras_retinanet/preprocessing/coco.py
@@ -40,6 +40,8 @@ class CocoGenerator(Generator):
         self.set_name  = set_name
         self.coco      = COCO(os.path.join(data_dir, 'annotations', 'instances_' + set_name + '.json'))
         self.image_ids = self.coco.getImgIds()
+        self.images    = self.coco.loadImgs(self.image_ids)
+        self.image_names = [image['file_name'] for image in self.images] 
 
         self.load_classes()
 
@@ -110,6 +112,11 @@ class CocoGenerator(Generator):
         """ Map label as used by the network to labels as used by COCO.
         """
         return self.coco_labels[label]
+        
+    def image_path(self, image_index):
+        """ Returns the image path for image_index.
+        """
+        return os.path.join(self.data_dir, self.image_names[image_index])
 
     def image_aspect_ratio(self, image_index):
         """ Compute the aspect ratio for an image with image_index.


### PR DESCRIPTION
This fixes the issue https://github.com/fizyr/keras-retinanet/issues/1113. However, I wasn't able to make it work at the `Generator` class level, thus I implemented the fix in the `CocoGenerator` class. I just add the lists `images` and `image_names` in the `__init__` method, and an `image_path` method which is based on the same method in the `CSVGenerator` class. I tested it on my custom dataset in COCO format, and it works.