### PR TITLE
Disable tf2 behavior.

### DIFF
--- a/keras_retinanet/backend/tensorflow_backend.py
+++ b/keras_retinanet/backend/tensorflow_backend.py
@@ -17,6 +17,12 @@ limitations under the License.
 import tensorflow
 
 
+def disable_tensorflow_v2_behavior():
+    """ See https://www.tensorflow.org/api_docs/python/tf/compat/v1/disable_tensorflow_v2_behavior .
+    """
+    tensorflow.compat.v1.disable_v2_behavior()
+
+
 def ones(*args, **kwargs):
     """ See https://www.tensorflow.org/api_docs/python/tf/ones .
     """

--- a/keras_retinanet/bin/convert_model.py
+++ b/keras_retinanet/bin/convert_model.py
@@ -27,9 +27,14 @@ if __name__ == "__main__" and __package__ is None:
     __package__ = "keras_retinanet.bin"
 
 # Change these to absolute imports if you copy this script outside the keras_retinanet package.
+from .. import backend
 from .. import models
 from ..utils.config import read_config_file, parse_anchor_parameters
 from ..utils.gpu import setup_gpu
+
+
+# Disable Tensorflow 2 behavior as we experience issues with it.
+backend.disable_tensorflow_v2_behavior()
 
 
 def parse_args(args):

--- a/keras_retinanet/bin/debug.py
+++ b/keras_retinanet/bin/debug.py
@@ -28,6 +28,7 @@ if __name__ == "__main__" and __package__ is None:
     __package__ = "keras_retinanet.bin"
 
 # Change these to absolute imports if you copy this script outside the keras_retinanet package.
+from .. import backend
 from ..preprocessing.pascal_voc import PascalVocGenerator
 from ..preprocessing.csv_generator import CSVGenerator
 from ..preprocessing.kitti import KittiGenerator
@@ -38,6 +39,10 @@ from ..utils.visualization import draw_annotations, draw_boxes, draw_caption
 from ..utils.anchors import anchors_for_shape, compute_gt_annotations
 from ..utils.config import read_config_file, parse_anchor_parameters
 from ..utils.image import random_visual_effect_generator
+
+
+# Disable Tensorflow 2 behavior as we experience issues with it.
+backend.disable_tensorflow_v2_behavior()
 
 
 def create_generator(args):

--- a/keras_retinanet/bin/evaluate.py
+++ b/keras_retinanet/bin/evaluate.py
@@ -98,7 +98,7 @@ def parse_args(args):
     parser.add_argument('model',              help='Path to RetinaNet model.')
     parser.add_argument('--convert-model',    help='Convert the model to an inference model (ie. the input is a training model).', action='store_true')
     parser.add_argument('--backbone',         help='The backbone of the model.', default='resnet50')
-    parser.add_argument('--gpu',              help='Id of the GPU to use (as reported by nvidia-smi).')
+    parser.add_argument('--gpu',              help='Id of the GPU to use (as reported by nvidia-smi).', type=int)
     parser.add_argument('--score-threshold',  help='Threshold on score to filter detections with (defaults to 0.05).', default=0.05, type=float)
     parser.add_argument('--iou-threshold',    help='IoU Threshold to count for a positive detection (defaults to 0.5).', default=0.5, type=float)
     parser.add_argument('--max-detections',   help='Max Detections per image (defaults to 100).', default=100, type=int)

--- a/keras_retinanet/bin/evaluate.py
+++ b/keras_retinanet/bin/evaluate.py
@@ -25,6 +25,7 @@ if __name__ == "__main__" and __package__ is None:
     __package__ = "keras_retinanet.bin"
 
 # Change these to absolute imports if you copy this script outside the keras_retinanet package.
+from .. import backend
 from .. import models
 from ..preprocessing.csv_generator import CSVGenerator
 from ..preprocessing.pascal_voc import PascalVocGenerator
@@ -32,6 +33,10 @@ from ..utils.config import read_config_file, parse_anchor_parameters
 from ..utils.eval import evaluate
 from ..utils.keras_version import check_keras_version
 from ..utils.gpu import setup_gpu
+
+
+# Disable Tensorflow 2 behavior as we experience issues with it.
+backend.disable_tensorflow_v2_behavior()
 
 
 def create_generator(args):

--- a/keras_retinanet/bin/train.py
+++ b/keras_retinanet/bin/train.py
@@ -413,7 +413,7 @@ def parse_args(args):
 
     parser.add_argument('--backbone',         help='Backbone model used by retinanet.', default='resnet50', type=str)
     parser.add_argument('--batch-size',       help='Size of the batches.', default=1, type=int)
-    parser.add_argument('--gpu',              help='Id of the GPU to use (as reported by nvidia-smi).')
+    parser.add_argument('--gpu',              help='Id of the GPU to use (as reported by nvidia-smi).', type=int)
     parser.add_argument('--multi-gpu',        help='Number of GPUs to use for parallel processing.', type=int, default=0)
     parser.add_argument('--multi-gpu-force',  help='Extra flag needed to enable (experimental) multi-gpu support.', action='store_true')
     parser.add_argument('--epochs',           help='Number of epochs to train.', type=int, default=50)

--- a/keras_retinanet/bin/train.py
+++ b/keras_retinanet/bin/train.py
@@ -32,6 +32,7 @@ if __name__ == "__main__" and __package__ is None:
     __package__ = "keras_retinanet.bin"
 
 # Change these to absolute imports if you copy this script outside the keras_retinanet package.
+from .. import backend
 from .. import layers  # noqa: F401
 from .. import losses
 from .. import models
@@ -49,6 +50,10 @@ from ..utils.model import freeze as freeze_model
 from ..utils.transform import random_transform_generator
 from ..utils.image import random_visual_effect_generator
 from ..utils.gpu import setup_gpu
+
+
+# Disable Tensorflow 2 behavior as we experience issues with it.
+backend.disable_tensorflow_v2_behavior()
 
 
 def makedirs(path):

--- a/tests/backend/test_common.py
+++ b/tests/backend/test_common.py
@@ -19,6 +19,10 @@ import keras
 import keras_retinanet.backend
 
 
+# Disable Tensorflow 2 behavior as we experience issues with it.
+keras_retinanet.backend.disable_tensorflow_v2_behavior()
+
+
 def test_bbox_transform_inv():
     boxes = np.array([[
         [100, 100, 200, 200],

--- a/tests/bin/test_train.py
+++ b/tests/bin/test_train.py
@@ -14,12 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import keras_retinanet.backend
 import keras_retinanet.bin.train
 import keras.backend
 
 import warnings
 
 import pytest
+
+
+# Disable Tensorflow 2 behavior as we experience issues with it.
+keras_retinanet.backend.disable_tensorflow_v2_behavior()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/layers/test_filter_detections.py
+++ b/tests/layers/test_filter_detections.py
@@ -15,9 +15,14 @@ limitations under the License.
 """
 
 import keras
+import keras_retinanet.backend
 import keras_retinanet.layers
 
 import numpy as np
+
+
+# Disable Tensorflow 2 behavior as we experience issues with it.
+keras_retinanet.backend.disable_tensorflow_v2_behavior()
 
 
 class TestFilterDetections(object):

--- a/tests/layers/test_misc.py
+++ b/tests/layers/test_misc.py
@@ -15,9 +15,14 @@ limitations under the License.
 """
 
 import keras
+import keras_retinanet.backend
 import keras_retinanet.layers
 
 import numpy as np
+
+
+# Disable Tensorflow 2 behavior as we experience issues with it.
+keras_retinanet.backend.disable_tensorflow_v2_behavior()
 
 
 class TestAnchors(object):

--- a/tests/models/test_densenet.py
+++ b/tests/models/test_densenet.py
@@ -18,8 +18,13 @@ import warnings
 import pytest
 import numpy as np
 import keras
+from keras_retinanet import backend
 from keras_retinanet import losses
 from keras_retinanet.models.densenet import DenseNetBackbone
+
+
+# Disable Tensorflow 2 behavior as we experience issues with it.
+backend.disable_tensorflow_v2_behavior()
 
 parameters = ['densenet121']
 

--- a/tests/models/test_mobilenet.py
+++ b/tests/models/test_mobilenet.py
@@ -18,8 +18,14 @@ import warnings
 import pytest
 import numpy as np
 import keras
+from keras_retinanet import backend
 from keras_retinanet import losses
 from keras_retinanet.models.mobilenet import MobileNetBackbone
+
+
+# Disable Tensorflow 2 behavior as we experience issues with it.
+backend.disable_tensorflow_v2_behavior()
+
 
 alphas = ['1.0']
 parameters = []


### PR DESCRIPTION
Since fully migrating to tf2 is going to be a bit difficult, the intermediate step is to disable v2 behavior. Unfortunately there is a bug in keras which prevents us from properly disabling v2 behavior, but it should hopefully be fixed with [this](https://github.com/keras-team/keras/pull/13476) PR.

Hopefully we can remove this at some point in the future, but for now let's get things working as they were using tensorflow 2.

ps. unit tests are still expected to fail due to the bug in Keras, but they should at least finish now. Let's wait merging this PR until the unit tests seem okay (aside from the Keras bug).