### PR TITLE
opencv-python -> opencv-python-headless

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ h5py
 keras
 matplotlib
 numpy>=1.14
-opencv-python>=3.3.0
+opencv-python-headless>=3.3.0
 pillow
 progressbar2
 tensorflow


### PR DESCRIPTION
opencv-python-headless package do not contain any GUI functionality. It is smaller and suitable for more restricted environments.