### PR TITLE
Bump minimum tensorflow version to 1.14, and check in all scripts.

### DIFF
--- a/keras_retinanet/bin/convert_model.py
+++ b/keras_retinanet/bin/convert_model.py
@@ -30,6 +30,8 @@ if __name__ == "__main__" and __package__ is None:
 from .. import models
 from ..utils.config import read_config_file, parse_anchor_parameters
 from ..utils.gpu import setup_gpu
+from ..utils.keras_version import check_keras_version
+from ..utils.tf_version import check_tf_version
 
 
 def parse_args(args):
@@ -50,6 +52,10 @@ def main(args=None):
     if args is None:
         args = sys.argv[1:]
     args = parse_args(args)
+
+    # make sure keras and tensorflow are the minimum required version
+    check_keras_version()
+    check_tf_version()
 
     # set modified tf session to avoid using the GPUs
     setup_gpu('cpu')

--- a/keras_retinanet/bin/debug.py
+++ b/keras_retinanet/bin/debug.py
@@ -41,12 +41,13 @@ from ..preprocessing.pascal_voc import PascalVocGenerator
 from ..preprocessing.csv_generator import CSVGenerator
 from ..preprocessing.kitti import KittiGenerator
 from ..preprocessing.open_images import OpenImagesGenerator
-from ..utils.keras_version import check_keras_version
-from ..utils.transform import random_transform_generator
-from ..utils.visualization import draw_annotations, draw_boxes, draw_caption
 from ..utils.anchors import anchors_for_shape, compute_gt_annotations
 from ..utils.config import read_config_file, parse_anchor_parameters
 from ..utils.image import random_visual_effect_generator
+from ..utils.keras_version import check_keras_version
+from ..utils.tf_version import check_tf_version
+from ..utils.transform import random_transform_generator
+from ..utils.visualization import draw_annotations, draw_boxes, draw_caption
 
 
 def create_generator(args):
@@ -292,8 +293,9 @@ def main(args=None):
         args = sys.argv[1:]
     args = parse_args(args)
 
-    # make sure keras is the minimum required version
+    # make sure keras and tensorflow are the minimum required version
     check_keras_version()
+    check_tf_version()
 
     # create the generator
     generator = create_generator(args)

--- a/keras_retinanet/bin/evaluate.py
+++ b/keras_retinanet/bin/evaluate.py
@@ -30,8 +30,9 @@ from ..preprocessing.csv_generator import CSVGenerator
 from ..preprocessing.pascal_voc import PascalVocGenerator
 from ..utils.config import read_config_file, parse_anchor_parameters
 from ..utils.eval import evaluate
-from ..utils.keras_version import check_keras_version
 from ..utils.gpu import setup_gpu
+from ..utils.keras_version import check_keras_version
+from ..utils.tf_version import check_tf_version
 
 
 def create_generator(args):
@@ -111,8 +112,9 @@ def main(args=None):
         args = sys.argv[1:]
     args = parse_args(args)
 
-    # make sure keras is the minimum required version
+    # make sure keras and tensorflow are the minimum required version
     check_keras_version()
+    check_tf_version()
 
     # optionally choose specific GPU
     if args.gpu:

--- a/keras_retinanet/bin/train.py
+++ b/keras_retinanet/bin/train.py
@@ -44,11 +44,12 @@ from ..preprocessing.open_images import OpenImagesGenerator
 from ..preprocessing.pascal_voc import PascalVocGenerator
 from ..utils.anchors import make_shapes_callback
 from ..utils.config import read_config_file, parse_anchor_parameters
+from ..utils.gpu import setup_gpu
+from ..utils.image import random_visual_effect_generator
 from ..utils.keras_version import check_keras_version
 from ..utils.model import freeze as freeze_model
+from ..utils.tf_version import check_tf_version
 from ..utils.transform import random_transform_generator
-from ..utils.image import random_visual_effect_generator
-from ..utils.gpu import setup_gpu
 
 
 def makedirs(path):
@@ -444,8 +445,9 @@ def main(args=None):
     # create object that stores backbone information
     backbone = models.backbone(args.backbone)
 
-    # make sure keras is the minimum required version
+    # make sure keras and tensorflow are the minimum required version
     check_keras_version()
+    check_tf_version()
 
     # optionally choose specific GPU
     if args.gpu:

--- a/keras_retinanet/utils/tf_version.py
+++ b/keras_retinanet/utils/tf_version.py
@@ -19,7 +19,7 @@ from __future__ import print_function
 import tensorflow as tf
 import sys
 
-MINIMUM_TF_VERSION = 1, 12, 0
+MINIMUM_TF_VERSION = 1, 14, 0
 
 
 def tf_version():
@@ -37,15 +37,15 @@ def tf_version_ok(minimum_tf_version=MINIMUM_TF_VERSION):
 
 
 def assert_tf_version(minimum_tf_version=MINIMUM_TF_VERSION):
-    """ Assert that the Keras version is up to date.
+    """ Assert that the Tensorflow version is up to date.
     """
     detected = tf.version.VERSION
     required = '.'.join(map(str, minimum_tf_version))
-    assert(tf_version() >= minimum_tf_version), 'You are using tf version {}. The minimum required version is {}.'.format(detected, required)
+    assert(tf_version() >= minimum_tf_version), 'You are using tensorflow version {}. The minimum required version is {}.'.format(detected, required)
 
 
 def check_tf_version():
-    """ Check that the Keras version is up to date. If it isn't, print an error message and exit the script.
+    """ Check that the Tensorflow version is up to date. If it isn't, print an error message and exit the script.
     """
     try:
         assert_tf_version()


### PR DESCRIPTION
This PR bumps minimum tensorflow version to 1.14 and calls the check in all scripts, as suggested at https://github.com/fizyr/keras-retinanet/issues/1149#issuecomment-545888936