### PR TITLE
Added support for SE and EfficientNet backbones

### DIFF
--- a/keras_retinanet/models/__init__.py
+++ b/keras_retinanet/models/__init__.py
@@ -59,6 +59,8 @@ def backbone(backbone_name):
         from .vgg import VGGBackbone as b
     elif 'densenet' in backbone_name:
         from .densenet import DenseNetBackbone as b
+    elif 'EfficientNet' in backbone_name:
+        from .effnet import EfficientNetBackbone as b
     else:
         raise NotImplementedError('Backbone class for  \'{}\' not implemented.'.format(backbone))
 

--- a/keras_retinanet/models/__init__.py
+++ b/keras_retinanet/models/__init__.py
@@ -49,7 +49,9 @@ class Backbone(object):
 def backbone(backbone_name):
     """ Returns a backbone object for the given backbone.
     """
-    if 'resnet' in backbone_name:
+    if 'seresnext' in backbone_name or 'seresnet' in backbone_name or 'senet' in backbone_name:
+        from .senet import SeBackbone as b
+    elif 'resnet' in backbone_name:
         from .resnet import ResNetBackbone as b
     elif 'mobilenet' in backbone_name:
         from .mobilenet import MobileNetBackbone as b

--- a/keras_retinanet/models/effnet.py
+++ b/keras_retinanet/models/effnet.py
@@ -48,7 +48,6 @@ class EfficientNetBackbone(Backbone):
         file_name = model_name + '_weights_tf_dim_ordering_tf_kernels_autoaugment_notop.h5'
         file_hash = WEIGHTS_HASHES[model_name][1]
         weights_path = get_file(file_name, BASE_WEIGHTS_PATH + file_name, cache_subdir='models', file_hash=file_hash)
-        # print('Image net weights loaded: {}'.format(weights_path))
         return weights_path
 
     def validate(self):

--- a/keras_retinanet/models/effnet.py
+++ b/keras_retinanet/models/effnet.py
@@ -1,0 +1,149 @@
+"""
+Copyright 2017-2018 Fizyr (https://fizyr.com)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import keras
+from keras.utils import get_file
+import keras_resnet
+import keras_resnet.models
+
+from . import retinanet
+from . import Backbone
+import efficientnet.keras as efn
+
+
+class EfficientNetBackbone(Backbone):
+    """ Describes backbone information and provides utility functions.
+    """
+
+    def __init__(self, backbone):
+        super(EfficientNetBackbone, self).__init__(backbone)
+        self.custom_objects.update(keras_resnet.custom_objects)
+        self.preprocess_image_func = None
+
+    def retinanet(self, *args, **kwargs):
+        """ Returns a retinanet model using the correct backbone.
+        """
+        return effnet_retinanet(*args, backbone=self.backbone, **kwargs)
+
+    def download_imagenet(self):
+        """ Downloads ImageNet weights and returns path to weights file.
+        """
+        return
+
+    def validate(self):
+        """ Checks whether the backbone string is correct.
+        """
+        allowed_backbones = ['EfficientNetB0', 'EfficientNetB1', 'EfficientNetB2', 'EfficientNetB3', 'EfficientNetB4',
+                             'EfficientNetB5', 'EfficientNetB6', 'EfficientNetB7']
+        backbone = self.backbone.split('_')[0]
+
+        if backbone not in allowed_backbones:
+            raise ValueError('Backbone (\'{}\') not in allowed backbones ({}).'.format(backbone, allowed_backbones))
+
+    def preprocess_image(self, inputs):
+        """ Takes as input an image and prepares it for being passed through the network.
+        """
+        return efn.preprocess_input(inputs)
+
+
+def effnet_retinanet(num_classes, backbone='EfficientNetB0', inputs=None, modifier=None, **kwargs):
+    """ Constructs a retinanet model using a resnet backbone.
+
+    Args
+        num_classes: Number of classes to predict.
+        backbone: Which backbone to use (one of ('resnet50', 'resnet101', 'resnet152')).
+        inputs: The inputs to the network (defaults to a Tensor of shape (None, None, 3)).
+        modifier: A function handler which can modify the backbone before using it in retinanet (this can be used to freeze backbone layers for example).
+
+    Returns
+        RetinaNet model with a ResNet backbone.
+    """
+    # choose default input
+    if inputs is None:
+        if keras.backend.image_data_format() == 'channels_first':
+            inputs = keras.layers.Input(shape=(3, None, None))
+        else:
+            # inputs = keras.layers.Input(shape=(224, 224, 3))
+            inputs = keras.layers.Input(shape=(None, None, 3))
+
+    # get last conv layer from the end of each block [28x28, 14x14, 7x7]
+    if backbone == 'EfficientNetB0':
+        model = efn.EfficientNetB0(input_tensor=inputs, include_top=False, weights='imagenet')
+    elif backbone == 'EfficientNetB1':
+        model = efn.EfficientNetB1(input_tensor=inputs, include_top=False, weights='imagenet')
+    elif backbone == 'EfficientNetB2':
+        model = efn.EfficientNetB2(input_tensor=inputs, include_top=False, weights='imagenet')
+    elif backbone == 'EfficientNetB3':
+        model = efn.EfficientNetB3(input_tensor=inputs, include_top=False, weights='imagenet')
+    elif backbone == 'EfficientNetB4':
+        model = efn.EfficientNetB4(input_tensor=inputs, include_top=False, weights='imagenet')
+    elif backbone == 'EfficientNetB5':
+        model = efn.EfficientNetB5(input_tensor=inputs, include_top=False, weights='imagenet')
+    elif backbone == 'EfficientNetB6':
+        model = efn.EfficientNetB6(input_tensor=inputs, include_top=False, weights='imagenet')
+    elif backbone == 'EfficientNetB7':
+        model = efn.EfficientNetB7(input_tensor=inputs, include_top=False, weights='imagenet')
+    else:
+        raise ValueError('Backbone (\'{}\') is invalid.'.format(backbone))
+
+    layer_outputs = ['block4a_expand_activation', 'block6a_expand_activation', 'top_activation']
+
+    layer_outputs = [
+        model.get_layer(name=layer_outputs[0]).output,  # 28x28
+        model.get_layer(name=layer_outputs[1]).output,  # 14x14
+        model.get_layer(name=layer_outputs[2]).output,  # 7x7
+    ]
+    # create the densenet backbone
+    model = keras.models.Model(inputs=inputs, outputs=layer_outputs, name=model.name)
+
+    # invoke modifier if given
+    if modifier:
+        model = modifier(model)
+
+    # create the full model
+    return retinanet.retinanet(inputs=inputs, num_classes=num_classes, backbone_layers=model.outputs, **kwargs)
+
+
+def EfficientNetB0_retinanet(num_classes, inputs=None, **kwargs):
+    return effnet_retinanet(num_classes=num_classes, backbone='EfficientNetB0', inputs=inputs, **kwargs)
+
+
+def EfficientNetB1_retinanet(num_classes, inputs=None, **kwargs):
+    return effnet_retinanet(num_classes=num_classes, backbone='EfficientNetB1', inputs=inputs, **kwargs)
+
+
+def EfficientNetB2_retinanet(num_classes, inputs=None, **kwargs):
+    return effnet_retinanet(num_classes=num_classes, backbone='EfficientNetB2', inputs=inputs, **kwargs)
+
+
+def EfficientNetB3_retinanet(num_classes, inputs=None, **kwargs):
+    return effnet_retinanet(num_classes=num_classes, backbone='EfficientNetB3', inputs=inputs, **kwargs)
+
+
+def EfficientNetB4_retinanet(num_classes, inputs=None, **kwargs):
+    return effnet_retinanet(num_classes=num_classes, backbone='EfficientNetB4', inputs=inputs, **kwargs)
+
+
+def EfficientNetB5_retinanet(num_classes, inputs=None, **kwargs):
+    return effnet_retinanet(num_classes=num_classes, backbone='EfficientNetB5', inputs=inputs, **kwargs)
+
+
+def EfficientNetB6_retinanet(num_classes, inputs=None, **kwargs):
+    return effnet_retinanet(num_classes=num_classes, backbone='EfficientNetB6', inputs=inputs, **kwargs)
+
+
+def EfficientNetB7_retinanet(num_classes, inputs=None, **kwargs):
+    return effnet_retinanet(num_classes=num_classes, backbone='EfficientNetB7', inputs=inputs, **kwargs)

--- a/keras_retinanet/models/effnet.py
+++ b/keras_retinanet/models/effnet.py
@@ -41,7 +41,15 @@ class EfficientNetBackbone(Backbone):
     def download_imagenet(self):
         """ Downloads ImageNet weights and returns path to weights file.
         """
-        return
+        from efficientnet.model import BASE_WEIGHTS_PATH
+        from efficientnet.model import WEIGHTS_HASHES
+
+        model_name = 'efficientnet-b' + self.backbone[-1]
+        file_name = model_name + '_weights_tf_dim_ordering_tf_kernels_autoaugment_notop.h5'
+        file_hash = WEIGHTS_HASHES[model_name][1]
+        weights_path = get_file(file_name, BASE_WEIGHTS_PATH + file_name, cache_subdir='models', file_hash=file_hash)
+        # print('Image net weights loaded: {}'.format(weights_path))
+        return weights_path
 
     def validate(self):
         """ Checks whether the backbone string is correct.
@@ -81,21 +89,21 @@ def effnet_retinanet(num_classes, backbone='EfficientNetB0', inputs=None, modifi
 
     # get last conv layer from the end of each block [28x28, 14x14, 7x7]
     if backbone == 'EfficientNetB0':
-        model = efn.EfficientNetB0(input_tensor=inputs, include_top=False, weights='imagenet')
+        model = efn.EfficientNetB0(input_tensor=inputs, include_top=False, weights=None)
     elif backbone == 'EfficientNetB1':
-        model = efn.EfficientNetB1(input_tensor=inputs, include_top=False, weights='imagenet')
+        model = efn.EfficientNetB1(input_tensor=inputs, include_top=False, weights=None)
     elif backbone == 'EfficientNetB2':
-        model = efn.EfficientNetB2(input_tensor=inputs, include_top=False, weights='imagenet')
+        model = efn.EfficientNetB2(input_tensor=inputs, include_top=False, weights=None)
     elif backbone == 'EfficientNetB3':
-        model = efn.EfficientNetB3(input_tensor=inputs, include_top=False, weights='imagenet')
+        model = efn.EfficientNetB3(input_tensor=inputs, include_top=False, weights=None)
     elif backbone == 'EfficientNetB4':
-        model = efn.EfficientNetB4(input_tensor=inputs, include_top=False, weights='imagenet')
+        model = efn.EfficientNetB4(input_tensor=inputs, include_top=False, weights=None)
     elif backbone == 'EfficientNetB5':
-        model = efn.EfficientNetB5(input_tensor=inputs, include_top=False, weights='imagenet')
+        model = efn.EfficientNetB5(input_tensor=inputs, include_top=False, weights=None)
     elif backbone == 'EfficientNetB6':
-        model = efn.EfficientNetB6(input_tensor=inputs, include_top=False, weights='imagenet')
+        model = efn.EfficientNetB6(input_tensor=inputs, include_top=False, weights=None)
     elif backbone == 'EfficientNetB7':
-        model = efn.EfficientNetB7(input_tensor=inputs, include_top=False, weights='imagenet')
+        model = efn.EfficientNetB7(input_tensor=inputs, include_top=False, weights=None)
     else:
         raise ValueError('Backbone (\'{}\') is invalid.'.format(backbone))
 

--- a/keras_retinanet/models/senet.py
+++ b/keras_retinanet/models/senet.py
@@ -1,0 +1,121 @@
+"""
+Copyright 2017-2018 Fizyr (https://fizyr.com)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import keras
+from keras.utils import get_file
+import keras_resnet
+import keras_resnet.models
+
+from . import retinanet
+from . import Backbone
+from classification_models.keras import Classifiers
+
+
+class SeBackbone(Backbone):
+    """ Describes backbone information and provides utility functions.
+    """
+
+    def __init__(self, backbone):
+        super(SeBackbone, self).__init__(backbone)
+        self.custom_objects.update(keras_resnet.custom_objects)
+        self.preprocess_image_func = None
+
+    def retinanet(self, *args, **kwargs):
+        """ Returns a retinanet model using the correct backbone.
+        """
+        _, self.preprocess_image_func = Classifiers.get(self.backbone)
+        return senet_retinanet(*args, backbone=self.backbone, **kwargs)
+
+    def download_imagenet(self):
+        """ Downloads ImageNet weights and returns path to weights file.
+        """
+        return
+
+    def validate(self):
+        """ Checks whether the backbone string is correct.
+        """
+        allowed_backbones = ['seresnet18', 'seresnet34', 'seresnet50', 'seresnet101', 'seresnet152',
+                             'seresnext50', 'seresnext101', 'senet154']
+        backbone = self.backbone.split('_')[0]
+
+        if backbone not in allowed_backbones:
+            raise ValueError('Backbone (\'{}\') not in allowed backbones ({}).'.format(backbone, allowed_backbones))
+
+    def preprocess_image(self, inputs):
+        """ Takes as input an image and prepares it for being passed through the network.
+        """
+        return self.preprocess_image_func(inputs)
+
+
+def senet_retinanet(num_classes, backbone='seresnext50', inputs=None, modifier=None, **kwargs):
+    """ Constructs a retinanet model using a resnet backbone.
+
+    Args
+        num_classes: Number of classes to predict.
+        backbone: Which backbone to use (one of ('resnet50', 'resnet101', 'resnet152')).
+        inputs: The inputs to the network (defaults to a Tensor of shape (None, None, 3)).
+        modifier: A function handler which can modify the backbone before using it in retinanet (this can be used to freeze backbone layers for example).
+
+    Returns
+        RetinaNet model with a ResNet backbone.
+    """
+    # choose default input
+    if inputs is None:
+        if keras.backend.image_data_format() == 'channels_first':
+            inputs = keras.layers.Input(shape=(3, None, None))
+        else:
+            # inputs = keras.layers.Input(shape=(224, 224, 3))
+            inputs = keras.layers.Input(shape=(None, None, 3))
+
+    classifier, _ = Classifiers.get(backbone)
+    model = classifier(input_tensor=inputs, include_top=False, weights='imagenet')
+
+    # get last conv layer from the end of each block [28x28, 14x14, 7x7]
+    if backbone == 'seresnet18' or backbone == 'seresnet34':
+        layer_outputs = ['stage3_unit1_relu1', 'stage4_unit1_relu1', 'relu1']
+    elif backbone == 'seresnet50':
+        layer_outputs = ['activation_36', 'activation_66', 'activation_81']
+    elif backbone == 'seresnet101':
+        layer_outputs = ['activation_36', 'activation_151', 'activation_166']
+    elif backbone == 'seresnet152':
+        layer_outputs = ['activation_56', 'activation_236', 'activation_251']
+    elif backbone == 'seresnext50':
+        layer_outputs = ['activation_37', 'activation_67', 'activation_81']
+    elif backbone == 'seresnext101':
+        layer_outputs = ['activation_37', 'activation_152', 'activation_166']
+    elif backbone == 'senet154':
+        layer_outputs = ['activation_59', 'activation_239', 'activation_253']
+    else:
+        raise ValueError('Backbone (\'{}\') is invalid.'.format(backbone))
+
+    layer_outputs = [
+        model.get_layer(name=layer_outputs[0]).output,  # 28x28
+        model.get_layer(name=layer_outputs[1]).output,  # 14x14
+        model.get_layer(name=layer_outputs[2]).output,  # 7x7
+    ]
+    # create the densenet backbone
+    model = keras.models.Model(inputs=inputs, outputs=layer_outputs, name=model.name)
+
+    # invoke modifier if given
+    if modifier:
+        model = modifier(model)
+
+    # create the full model
+    return retinanet.retinanet(inputs=inputs, num_classes=num_classes, backbone_layers=model.outputs, **kwargs)
+
+
+def seresnext50_retinanet(num_classes, inputs=None, **kwargs):
+    return senet_retinanet(num_classes=num_classes, backbone='seresnext50', inputs=inputs, **kwargs)

--- a/keras_retinanet/models/senet.py
+++ b/keras_retinanet/models/senet.py
@@ -117,5 +117,33 @@ def senet_retinanet(num_classes, backbone='seresnext50', inputs=None, modifier=N
     return retinanet.retinanet(inputs=inputs, num_classes=num_classes, backbone_layers=model.outputs, **kwargs)
 
 
+def seresnet18_retinanet(num_classes, inputs=None, **kwargs):
+    return senet_retinanet(num_classes=num_classes, backbone='seresnet18', inputs=inputs, **kwargs)
+
+
+def seresnet34_retinanet(num_classes, inputs=None, **kwargs):
+    return senet_retinanet(num_classes=num_classes, backbone='seresnet34', inputs=inputs, **kwargs)
+
+
+def seresnet50_retinanet(num_classes, inputs=None, **kwargs):
+    return senet_retinanet(num_classes=num_classes, backbone='seresnet50', inputs=inputs, **kwargs)
+
+
+def seresnet101_retinanet(num_classes, inputs=None, **kwargs):
+    return senet_retinanet(num_classes=num_classes, backbone='seresnet101', inputs=inputs, **kwargs)
+
+
+def seresnet152_retinanet(num_classes, inputs=None, **kwargs):
+    return senet_retinanet(num_classes=num_classes, backbone='seresnet152', inputs=inputs, **kwargs)
+
+
 def seresnext50_retinanet(num_classes, inputs=None, **kwargs):
     return senet_retinanet(num_classes=num_classes, backbone='seresnext50', inputs=inputs, **kwargs)
+
+
+def seresnext101_retinanet(num_classes, inputs=None, **kwargs):
+    return senet_retinanet(num_classes=num_classes, backbone='seresnext101', inputs=inputs, **kwargs)
+
+
+def senet154_retinanet(num_classes, inputs=None, **kwargs):
+    return senet_retinanet(num_classes=num_classes, backbone='senet154', inputs=inputs, **kwargs)

--- a/keras_retinanet/models/senet.py
+++ b/keras_retinanet/models/senet.py
@@ -42,7 +42,18 @@ class SeBackbone(Backbone):
     def download_imagenet(self):
         """ Downloads ImageNet weights and returns path to weights file.
         """
-        return
+        from classification_models.weights import WEIGHTS_COLLECTION
+
+        weights_path = None
+        for el in WEIGHTS_COLLECTION:
+            if el['model'] == self.backbone and el['include_top'] == False:
+                weights_path = get_file(el['name'], el['url'], cache_subdir='models', file_hash=el['md5'])
+
+        if weights_path is None:
+            raise ValueError('Unable to find imagenet weights for backbone {}!'.format(self.backbone))
+
+        # print('Image net weights loaded: {}'.format(weights_path))
+        return weights_path
 
     def validate(self):
         """ Checks whether the backbone string is correct.
@@ -81,7 +92,7 @@ def senet_retinanet(num_classes, backbone='seresnext50', inputs=None, modifier=N
             inputs = keras.layers.Input(shape=(None, None, 3))
 
     classifier, _ = Classifiers.get(backbone)
-    model = classifier(input_tensor=inputs, include_top=False, weights='imagenet')
+    model = classifier(input_tensor=inputs, include_top=False, weights=None)
 
     # get last conv layer from the end of each block [28x28, 14x14, 7x7]
     if backbone == 'seresnet18' or backbone == 'seresnet34':

--- a/keras_retinanet/models/senet.py
+++ b/keras_retinanet/models/senet.py
@@ -52,7 +52,6 @@ class SeBackbone(Backbone):
         if weights_path is None:
             raise ValueError('Unable to find imagenet weights for backbone {}!'.format(self.backbone))
 
-        # print('Image net weights loaded: {}'.format(weights_path))
         return weights_path
 
     def validate(self):


### PR DESCRIPTION
Added support for following pre-trained backbones:
'seresnet18', 'seresnet34', 'seresnet50', 'seresnet101', 'seresnet152', 'seresnext50', 'seresnext101', 'senet154', 'EfficientNetB0', 'EfficientNetB1', 'EfficientNetB2', 'EfficientNetB3', 'EfficientNetB4', 'EfficientNetB5', 'EfficientNetB6', 'EfficientNetB7'

It has dependency on following python modules: '[classification_models](https://github.com/qubvel/classification_models)' and '[efficientnet](https://github.com/qubvel/efficientnet)'. But they will be called only if user will use these backbones.