### PR TITLE
Add image_path methods to KITTI and Pascal VOC datasets.

### DIFF
--- a/keras_retinanet/preprocessing/coco.py
+++ b/keras_retinanet/preprocessing/coco.py
@@ -110,7 +110,7 @@ class CocoGenerator(Generator):
         """ Map label as used by the network to labels as used by COCO.
         """
         return self.coco_labels[label]
-        
+
     def image_path(self, image_index):
         """ Returns the image path for image_index.
         """

--- a/keras_retinanet/preprocessing/generator.py
+++ b/keras_retinanet/preprocessing/generator.py
@@ -131,6 +131,11 @@ class Generator(keras.utils.Sequence):
         """
         raise NotImplementedError('image_aspect_ratio method not implemented')
 
+    def image_path(self, image_index):
+        """ Get the path to an image.
+        """
+        raise NotImplementedError('image_path method not implemented')
+
     def load_image(self, image_index):
         """ Load an image at the image_index.
         """

--- a/keras_retinanet/preprocessing/kitti.py
+++ b/keras_retinanet/preprocessing/kitti.py
@@ -142,10 +142,15 @@ class KittiGenerator(Generator):
         image = Image.open(self.images[image_index])
         return float(image.width) / float(image.height)
 
+    def image_path(self, image_index):
+        """ Get the path to an image.
+        """
+        return self.images[image_index]
+
     def load_image(self, image_index):
         """ Load an image at the image_index.
         """
-        return read_image_bgr(self.images[image_index])
+        return read_image_bgr(self.image_path(image_index))
 
     def load_annotations(self, image_index):
         """ Load annotations for an image_index.

--- a/keras_retinanet/preprocessing/pascal_voc.py
+++ b/keras_retinanet/preprocessing/pascal_voc.py
@@ -139,11 +139,15 @@ class PascalVocGenerator(Generator):
         image = Image.open(path)
         return float(image.width) / float(image.height)
 
+    def image_path(self, image_index):
+        """ Get the path to an image.
+        """
+        return os.path.join(self.data_dir, 'JPEGImages', self.image_names[image_index] + self.image_extension)
+
     def load_image(self, image_index):
         """ Load an image at the image_index.
         """
-        path = os.path.join(self.data_dir, 'JPEGImages', self.image_names[image_index] + self.image_extension)
-        return read_image_bgr(path)
+        return read_image_bgr(self.image_path(image_index))
 
     def __parse_annotation(self, element):
         """ Parse an annotation given an XML element.


### PR DESCRIPTION
@AndreaPi this should add `image_path` to KITTI and Pascal VOC datasets (and also add it to the abstract Generator class).