### PR TITLE
Callback Evaluate expect tuple returned by utils.eval.evaluate 

### DIFF
--- a/keras_retinanet/callbacks/eval.py
+++ b/keras_retinanet/callbacks/eval.py
@@ -60,7 +60,7 @@ class Evaluate(keras.callbacks.Callback):
         logs = logs or {}
 
         # run evaluation
-        average_precisions = evaluate(
+        average_precisions, inference_time = evaluate(
             self.generator,
             self.model,
             iou_threshold=self.iou_threshold,


### PR DESCRIPTION
A call to `utils.eval.evaluate` in `callbacks.eval.Evaluate` didn't reflect that the inference time is returned next to the dict of precisions.
(I didn't know whether there's a preferred way of ignoring return values within the code base, so this fix is just an arbitrary suggestion.)