### PR TITLE
modified sequence of densenet

### DIFF
--- a/keras_retinanet/models/__init__.py
+++ b/keras_retinanet/models/__init__.py
@@ -49,16 +49,16 @@ class Backbone(object):
 def backbone(backbone_name):
     """ Returns a backbone object for the given backbone.
     """
-    if 'seresnext' in backbone_name or 'seresnet' in backbone_name or 'senet' in backbone_name:
+    if 'densenet' in backbone_name:
+        from .densenet import DenseNetBackbone as b
+    elif 'seresnext' in backbone_name or 'seresnet' in backbone_name or 'senet' in backbone_name:
         from .senet import SeBackbone as b
     elif 'resnet' in backbone_name:
         from .resnet import ResNetBackbone as b
     elif 'mobilenet' in backbone_name:
         from .mobilenet import MobileNetBackbone as b
     elif 'vgg' in backbone_name:
-        from .vgg import VGGBackbone as b
-    elif 'densenet' in backbone_name:
-        from .densenet import DenseNetBackbone as b
+        from .vgg import VGGBackbone as b   
     elif 'EfficientNet' in backbone_name:
         from .effnet import EfficientNetBackbone as b
     else:


### PR DESCRIPTION
I've tried to use densenet as a backbone but the model detected senet instead of densenet. 
Since 'senet' is a substring of 'densenet', the conditional statement below (models/__init__.py) could not reach to densenet.
```
def backbone(backbone_name):
    """ Returns a backbone object for the given backbone.
    """
    if 'seresnext' in backbone_name or 'seresnet' in backbone_name or 'senet' in backbone_name:
        from .senet import SeBackbone as b
    elif 'resnet' in backbone_name:
        from .resnet import ResNetBackbone as b
    elif 'mobilenet' in backbone_name:
        from .mobilenet import MobileNetBackbone as b
    elif 'vgg' in backbone_name:
        from .vgg import VGGBackbone as b
    elif 'densenet' in backbone_name:
        from .densenet import DenseNetBackbone as b
    elif 'EfficientNet' in backbone_name:
        from .effnet import EfficientNetBackbone as b
    else:
        raise NotImplementedError('Backbone class for  \'{}\' not implemented.'.format(backbone))

    return b(backbone_name)
```

