### PR TITLE
Solution to exception in gpu selection

### DIFF
--- a/keras_retinanet/utils/gpu.py
+++ b/keras_retinanet/utils/gpu.py
@@ -34,7 +34,7 @@ def setup_gpu(gpu_id):
                     tf.config.experimental.set_memory_growth(gpu, True)
 
                 # Use only the selcted gpu.
-                tf.config.experimental.set_visible_devices(gpus[gpu_id], 'GPU')
+                tf.config.experimental.set_visible_devices(gpus[int(gpu_id)], 'GPU')
             except RuntimeError as e:
                 # Visible devices must be set before GPUs have been initialized.
                 print(e)


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/data/students_home/fschipani/.local/bin/retinanet-evaluate", line 10, in <module>
    sys.exit(main())
  File "/data/students_home/fschipani/.local/lib/python3.7/site-packages/keras_retinanet/bin/evaluate.py", line 121, in main
    setup_gpu(args.gpu)
  File "/data/students_home/fschipani/.local/lib/python3.7/site-packages/keras_retinanet/utils/gpu.py", line 37, in setup_gpu
    tf.config.experimental.set_visible_devices(gpus[gpu_id], 'GPU')
TypeError: list indices must be integers or slices, not str
```