### PR TITLE
Fix syntax error in train.py

### DIFF
--- a/keras_retinanet/bin/train.py
+++ b/keras_retinanet/bin/train.py
@@ -519,7 +519,7 @@ def main(args=None):
         use_multiprocessing=args.multiprocessing,
         max_queue_size=args.max_queue_size,
         validation_steps = args.steps_for_validation,
-        validation_data=validation_generator
+        validation_data=validation_generator,
         initial_epoch=args.initial_epoch
     )
 


### PR DESCRIPTION
This PR fixes a syntax error in `train.py`, reported in #1219 by @sv-youn.