### PR TITLE
Pass preprocess_image function to generators in evaluate.py

### DIFF
--- a/keras_retinanet/bin/evaluate.py
+++ b/keras_retinanet/bin/evaluate.py
@@ -117,7 +117,7 @@ def parse_args(args):
 
 
 def main(args=None):
-    # parse argumentsbin
+    # parse arguments
     if args is None:
         args = sys.argv[1:]
     args = parse_args(args)


### PR DESCRIPTION
I've encountered a problem similar to this issue: https://github.com/fizyr/keras-retinanet/issues/647 (with custom backbone, mobilenetv3, not in the "zoo"). Here https://github.com/fizyr/keras-retinanet/issues/1055#issuecomment-523873503 @mariaculman18 offered a solution that worked for me and seems to be reasonable. The author is not going to create a pull request, but I decided to do so, as other users with non-resnet50 backbones can be affected.  