### PR TITLE
correct description of anchor_targets_bbox() function parameters

### DIFF
--- a/keras_retinanet/utils/anchors.py
+++ b/keras_retinanet/utils/anchors.py
@@ -63,7 +63,7 @@ def anchor_targets_bbox(
     Args
         anchors: np.array of annotations of shape (N, 4) for (x1, y1, x2, y2).
         image_group: List of BGR images.
-        annotations_group: List of annotations (np.array of shape (N, 5) for (x1, y1, x2, y2, label)).
+        annotations_group: List of annotation dictionaries with each annotation containing 'labels' and 'bboxes' of an image.
         num_classes: Number of classes to predict.
         mask_shape: If the image is padded with zeros, mask_shape can be used to mark the relevant part of the image.
         negative_overlap: IoU overlap for negative anchors (all anchors with overlap < negative_overlap are negative).


### PR DESCRIPTION
annotations_group is a list of dictionaries which was incorrectly described as "np.array of shape (N, 5) for (x1, y1, x2, y2, label)" previously