### PR TITLE
Correct computation of box area

### DIFF
--- a/keras_retinanet/utils/compute_overlap.pyx
+++ b/keras_retinanet/utils/compute_overlap.pyx
@@ -30,23 +30,23 @@ def compute_overlap(
     cdef unsigned int k, n
     for k in range(K):
         box_area = (
-            (query_boxes[k, 2] - query_boxes[k, 0] + 1) *
-            (query_boxes[k, 3] - query_boxes[k, 1] + 1)
+            (query_boxes[k, 2] - query_boxes[k, 0]) *
+            (query_boxes[k, 3] - query_boxes[k, 1])
         )
         for n in range(N):
             iw = (
                 min(boxes[n, 2], query_boxes[k, 2]) -
-                max(boxes[n, 0], query_boxes[k, 0]) + 1
+                max(boxes[n, 0], query_boxes[k, 0]) 
             )
             if iw > 0:
                 ih = (
                     min(boxes[n, 3], query_boxes[k, 3]) -
-                    max(boxes[n, 1], query_boxes[k, 1]) + 1
+                    max(boxes[n, 1], query_boxes[k, 1]) 
                 )
                 if ih > 0:
                     ua = np.float64(
-                        (boxes[n, 2] - boxes[n, 0] + 1) *
-                        (boxes[n, 3] - boxes[n, 1] + 1) +
+                        (boxes[n, 2] - boxes[n, 0] ) *
+                        (boxes[n, 3] - boxes[n, 1] ) +
                         box_area - iw * ih
                     )
                     overlaps[n, k] = iw * ih / ua


### PR DESCRIPTION
Hi,
This PR corrects the computation of box area in `compute_overlap` function.
This correction is based on [this](https://github.com/matterport/Mask_RCNN).
Regards,
Bruno