### PR TITLE
Removing redundant .copy() in load_image_bgr()

### DIFF
--- a/keras_retinanet/utils/image.py
+++ b/keras_retinanet/utils/image.py
@@ -29,8 +29,8 @@ def read_image_bgr(path):
         path: Path to the image.
     """
     # We deliberately don't use cv2.imread here, since it gives no feedback on errors while reading the image.
-    image = np.asarray(Image.open(path).convert('RGB'))
-    return image[:, :, ::-1].copy()
+    image = np.ascontiguousarray(Image.open(path).convert('RGB'))
+    return image[:, :, ::-1]
 
 
 def preprocess_image(x, mode='caffe'):

--- a/tests/preprocessing/test_image.py
+++ b/tests/preprocessing/test_image.py
@@ -11,7 +11,7 @@ _STUB_IMG_FNAME = 'stub-image.jpg'
 @pytest.fixture(autouse=True)
 def run_around_tests(tmp_path):
     """Create a temp image for test"""
-    rand_img = np.random.randint(0, 255, (10, 10, 3), dtype='uint8')
+    rand_img = np.random.randint(0, 255, (3, 3, 3), dtype='uint8')
     Image.fromarray(rand_img).save(os.path.join(tmp_path, _STUB_IMG_FNAME))
     yield
 
@@ -23,7 +23,5 @@ def test_read_image_bgr(tmp_path):
         stub_image_path).convert('RGB'))[:, :, ::-1]
     loaded_image = image.read_image_bgr(stub_image_path)
 
-    # Assert loaded image is C-ordered
-    assert loaded_image.flags['C_CONTIGUOUS'] is True
     # Assert images are equal
-    assert np.testing.assert_array_equal(original_img, loaded_image) is None
+    np.testing.assert_array_equal(original_img, loaded_image)

--- a/tests/preprocessing/test_image.py
+++ b/tests/preprocessing/test_image.py
@@ -1,0 +1,29 @@
+import os
+import pytest
+from pathlib import Path
+from PIL import Image
+from keras_retinanet.utils import image
+import numpy as np
+
+_STUB_IMG_FNAME = 'stub-image.jpg'
+
+
+@pytest.fixture(autouse=True)
+def run_around_tests(tmp_path):
+    """Create a temp image for test"""
+    rand_img = np.random.randint(0, 255, (10, 10, 3), dtype='uint8')
+    Image.fromarray(rand_img).save(os.path.join(tmp_path, _STUB_IMG_FNAME))
+    yield
+
+
+def test_read_image_bgr(tmp_path):
+    stub_image_path = os.path.join(tmp_path, _STUB_IMG_FNAME)
+
+    original_img = np.asarray(Image.open(
+        stub_image_path).convert('RGB'))[:, :, ::-1]
+    loaded_image = image.read_image_bgr(stub_image_path)
+
+    # Assert loaded image is C-ordered
+    assert loaded_image.flags['C_CONTIGUOUS'] is True
+    # Assert images are equal
+    assert np.testing.assert_array_equal(original_img, loaded_image) is None


### PR DESCRIPTION
While investigating ways to improve image loading, I noticed that `load_image_bgr` performs a `copy()` in the end which seemed redundant.  

According to @hgaiser in #1373, it is due to some other code expecting the image to be C-ordered, and using `np.ascontiguousarray()` was suggested.  

However, despite the aforementioned function calls `np.array(..., copy=False)` in it's implementation, I suspected that a copy would still occur, mainly because after inversing the channels dimension in the `load_image_bgr`, the array is no longer marked as having C-order.  
You can verify this yourself with a mock example:
```python
import numpy as np

rand_img = np.random.randint(0, 255, (3, 3, 3), dtype='uint8')
assert rand_img.flags['C_CONTIGUOUS'] is True
assert rand_img[:, :, ::-1].flags['C_CONTIGUOUS'] is False
```
And indeed, there's no runtime difference between using one or another:  
```python
import numpy as np
import timeit
rand_img = np.random.randint(0, 255, (1000, 1000, 3), dtype='uint8')


def copy():
    rand_img[:, :, ::-1].copy()


def ascontiguousarray():
    np.ascontiguousarray(rand_img[:, :, ::-1])

print('copy took', timeit.timeit(
        "copy()", setup="from __main__ import copy", number=100000)/100000, 'seconds on average')
print('ascontiguousarray took', timeit.timeit("ascontiguousarray()",
        setup="from __main__ import ascontiguousarray", number=100000)/100000, 'seconds on average')
```

```python
copy took 0.00637431571855 seconds on average
ascontiguousarray took 0.0063767184182100005 seconds on average
```

The weird thing is, after the inversion `flags['F_CONTIGUOUS']` is also False.  
Thus I suspect that perhaps the array is C-ordered but the flags are set to False because of the view object generated by the inverse operation.  

I have made a [Colab Notebook](https://colab.research.google.com/drive/1EehEO3Z5UbrOTwHj4JB_X1kNVlkmFODF?usp=sharing) to check that the evaluation on COCO remains the same even without the `copy()`. And to verify that it incurs a performance increase:
```python
import numpy as np
from PIL import Image
import timeit
rand_img = np.random.randint(0, 255, (1000, 1000, 3), dtype='uint8')


def copy():
    image = np.asarray(Image.fromarray(rand_img).convert('RGB'))
    return image[:, :, ::-1].copy()


def ascontiguousarray():
    image = np.ascontiguousarray(Image.fromarray(rand_img).convert('RGB'))
    return image[:, :, ::-1]


print('copy took', timeit.timeit(
        "copy()", setup="from __main__ import copy", number=1000)/1000, 'seconds on average')
print('ascontiguousarray took', timeit.timeit("ascontiguousarray()",
         setup="from __main__ import ascontiguousarray", number=1000)/1000, 'seconds on average')
``` 

```python
copy took 0.01350084822900044 seconds on average
ascontiguousarray took 0.003240786004000256 seconds on average
```
Around ~X4 faster (CPU depended) single image loading.  
In the provided notebook we can see an X3 improvement on evaluation on the whole COCO dataset.

I also thought about enforcing the C-order flag to be truth, but couldn't find a way in which it didn't perform copy behind the scenes, also `np.asarray(..., order='C')` didn't work.  
