### PR TITLE
Pyramid level customization

### DIFF
--- a/keras_retinanet/bin/convert_model.py
+++ b/keras_retinanet/bin/convert_model.py
@@ -28,7 +28,7 @@ if __name__ == "__main__" and __package__ is None:
 
 # Change these to absolute imports if you copy this script outside the keras_retinanet package.
 from .. import models
-from ..utils.config import read_config_file, parse_anchor_parameters
+from ..utils.config import read_config_file, parse_anchor_parameters, parse_pyramid_levels
 from ..utils.gpu import setup_gpu
 from ..utils.keras_version import check_keras_version
 from ..utils.tf_version import check_tf_version
@@ -74,7 +74,6 @@ def main(args=None):
 
         if 'pyramid_levels' in args.config:
             pyramid_levels = parse_pyramid_levels(args.config)
-            print('pyramid levels are', pyramid_levels)
 
     # load the model
     model = models.load_model(args.model_in, backbone_name=args.backbone)

--- a/keras_retinanet/bin/convert_model.py
+++ b/keras_retinanet/bin/convert_model.py
@@ -66,10 +66,15 @@ def main(args=None):
 
     # optionally load config parameters
     anchor_parameters = None
+    pyramid_levels = None
     if args.config:
         args.config = read_config_file(args.config)
         if 'anchor_parameters' in args.config:
             anchor_parameters = parse_anchor_parameters(args.config)
+
+        if 'pyramid_levels' in args.config:
+            pyramid_levels = parse_pyramid_levels(args.config)
+            print('pyramid levels are', pyramid_levels)
 
     # load the model
     model = models.load_model(args.model_in, backbone_name=args.backbone)
@@ -83,6 +88,7 @@ def main(args=None):
         nms=args.nms,
         class_specific_filter=args.class_specific_filter,
         anchor_params=anchor_parameters,
+        pyramid_levels=pyramid_levels,
         nms_threshold=args.nms_threshold,
         score_threshold=args.score_threshold,
         max_detections=args.max_detections,

--- a/keras_retinanet/bin/debug.py
+++ b/keras_retinanet/bin/debug.py
@@ -215,7 +215,7 @@ def run(generator, args, anchor_params, pyramid_levels):
                 image, image_scale = generator.resize_image(image)
                 annotations['bboxes'] *= image_scale
 
-            anchors = anchors_for_shape(image.shape, anchor_params=anchor_params, pyramid_levels = pyramid_levels)
+            anchors = anchors_for_shape(image.shape, anchor_params=anchor_params, pyramid_levels=pyramid_levels)
             positive_indices, _, max_indices = compute_gt_annotations(anchors, annotations['bboxes'])
 
             # draw anchors on the image

--- a/keras_retinanet/bin/evaluate.py
+++ b/keras_retinanet/bin/evaluate.py
@@ -29,7 +29,7 @@ from .. import models
 from ..preprocessing.csv_generator import CSVGenerator
 from ..preprocessing.pascal_voc import PascalVocGenerator
 from ..utils.anchors import make_shapes_callback
-from ..utils.config import read_config_file, parse_anchor_parameters
+from ..utils.config import read_config_file, parse_anchor_parameters, parse_pyramid_levels
 from ..utils.eval import evaluate
 from ..utils.gpu import setup_gpu
 from ..utils.keras_version import check_keras_version
@@ -150,7 +150,6 @@ def main(args=None):
     if args.config and 'pyramid_levels' in args.config:
         pyramid_levels = parse_pyramid_levels(args.config)
 
-
     # load the model
     print('Loading model, this may take a second...')
     model = models.load_model(args.model, backbone_name=args.backbone)
@@ -158,7 +157,7 @@ def main(args=None):
 
     # optionally convert the model
     if args.convert_model:
-        model = models.convert_model(model, anchor_params=anchor_params, pyramid_levels = pyramid_levels)
+        model = models.convert_model(model, anchor_params=anchor_params, pyramid_levels=pyramid_levels)
 
     # print model summary
     # print(model.summary())

--- a/keras_retinanet/bin/evaluate.py
+++ b/keras_retinanet/bin/evaluate.py
@@ -144,8 +144,12 @@ def main(args=None):
 
     # optionally load anchor parameters
     anchor_params = None
+    pyramid_levels = None
     if args.config and 'anchor_parameters' in args.config:
         anchor_params = parse_anchor_parameters(args.config)
+    if args.config and 'pyramid_levels' in args.config:
+        pyramid_levels = parse_pyramid_levels(args.config)
+
 
     # load the model
     print('Loading model, this may take a second...')
@@ -154,7 +158,7 @@ def main(args=None):
 
     # optionally convert the model
     if args.convert_model:
-        model = models.convert_model(model, anchor_params=anchor_params)
+        model = models.convert_model(model, anchor_params=anchor_params, pyramid_levels = pyramid_levels)
 
     # print model summary
     # print(model.summary())

--- a/keras_retinanet/bin/train.py
+++ b/keras_retinanet/bin/train.py
@@ -43,7 +43,7 @@ from ..preprocessing.kitti import KittiGenerator
 from ..preprocessing.open_images import OpenImagesGenerator
 from ..preprocessing.pascal_voc import PascalVocGenerator
 from ..utils.anchors import make_shapes_callback
-from ..utils.config import read_config_file, parse_anchor_parameters
+from ..utils.config import read_config_file, parse_anchor_parameters, parse_pyramid_levels
 from ..utils.gpu import setup_gpu
 from ..utils.image import random_visual_effect_generator
 from ..utils.keras_version import check_keras_version
@@ -102,6 +102,9 @@ def create_models(backbone_retinanet, num_classes, weights, multi_gpu=0,
     if config and 'anchor_parameters' in config:
         anchor_params = parse_anchor_parameters(config)
         num_anchors   = anchor_params.num_anchors()
+    if config and 'pyramid_levels' in config:
+        pyramid_levels = parse_pyramid_levels(config)
+        print('pyramid levels are', pyramid_levels)
 
     # Keras recommends initialising a multi-gpu model on the CPU to ease weight sharing, and to prevent OOM errors.
     # optionally wrap in a parallel model

--- a/keras_retinanet/bin/train.py
+++ b/keras_retinanet/bin/train.py
@@ -488,7 +488,7 @@ def main(args=None):
         if args.config and 'pyramid_levels' in args.config:
             pyramid_levels = parse_pyramid_levels(args.config)
 
-        prediction_model = retinanet_bbox(model=model, anchor_params=anchor_params, pyramid_levels = pyramid_levels)
+        prediction_model = retinanet_bbox(model=model, anchor_params=anchor_params, pyramid_levels=pyramid_levels)
     else:
         weights = args.weights
         # default to imagenet if nothing else is specified

--- a/keras_retinanet/bin/train.py
+++ b/keras_retinanet/bin/train.py
@@ -105,21 +105,20 @@ def create_models(backbone_retinanet, num_classes, weights, multi_gpu=0,
         num_anchors   = anchor_params.num_anchors()
     if config and 'pyramid_levels' in config:
         pyramid_levels = parse_pyramid_levels(config)
-        print('pyramid levels are', pyramid_levels)
 
     # Keras recommends initialising a multi-gpu model on the CPU to ease weight sharing, and to prevent OOM errors.
     # optionally wrap in a parallel model
     if multi_gpu > 1:
         from keras.utils import multi_gpu_model
         with tf.device('/cpu:0'):
-            model = model_with_weights(backbone_retinanet(num_classes, num_anchors=num_anchors, modifier=modifier,pyramid_levels=pyramid_levels), weights=weights, skip_mismatch=True)
+            model = model_with_weights(backbone_retinanet(num_classes, num_anchors=num_anchors, modifier=modifier, pyramid_levels=pyramid_levels), weights=weights, skip_mismatch=True)
         training_model = multi_gpu_model(model, gpus=multi_gpu)
     else:
         model          = model_with_weights(backbone_retinanet(num_classes, num_anchors=num_anchors, modifier=modifier, pyramid_levels=pyramid_levels), weights=weights, skip_mismatch=True)
         training_model = model
 
     # make prediction model
-    prediction_model = retinanet_bbox(model=model, anchor_params=anchor_params, pyramid_levels = pyramid_levels)
+    prediction_model = retinanet_bbox(model=model, anchor_params=anchor_params, pyramid_levels=pyramid_levels)
 
     # compile model
     training_model.compile(
@@ -488,7 +487,6 @@ def main(args=None):
             anchor_params = parse_anchor_parameters(args.config)
         if args.config and 'pyramid_levels' in args.config:
             pyramid_levels = parse_pyramid_levels(args.config)
-            print('pyramid levels are', pyramid_levels)
 
         prediction_model = retinanet_bbox(model=model, anchor_params=anchor_params, pyramid_levels = pyramid_levels)
     else:

--- a/keras_retinanet/models/densenet.py
+++ b/keras_retinanet/models/densenet.py
@@ -93,13 +93,21 @@ def densenet_retinanet(num_classes, backbone='densenet121', inputs=None, modifie
     layer_outputs = [model.get_layer(name='conv{}_block{}_concat'.format(idx + 2, block_num)).output for idx, block_num in enumerate(blocks)]
 
     # create the densenet backbone
-    model = keras.models.Model(inputs=inputs, outputs=layer_outputs[1:], name=model.name)
+    # layer_outputs contains 4 layers
+    model = keras.models.Model(inputs=inputs, outputs=layer_outputs, name=model.name)
 
     # invoke modifier if given
     if modifier:
         model = modifier(model)
 
     # create the full model
-    model = retinanet.retinanet(inputs=inputs, num_classes=num_classes, backbone_layers=model.outputs, **kwargs)
+    backbone_layers = {
+        'C2' : model.outputs[0],
+        'C3' : model.outputs[1],
+        'C4' : model.outputs[2],
+        'C5' : model.outputs[3]
+        }
+
+    model = retinanet.retinanet(inputs=inputs, num_classes=num_classes, backbone_layers=backbone_layers, **kwargs)
 
     return model

--- a/keras_retinanet/models/densenet.py
+++ b/keras_retinanet/models/densenet.py
@@ -102,11 +102,11 @@ def densenet_retinanet(num_classes, backbone='densenet121', inputs=None, modifie
 
     # create the full model
     backbone_layers = {
-        'C2' : model.outputs[0],
-        'C3' : model.outputs[1],
-        'C4' : model.outputs[2],
-        'C5' : model.outputs[3]
-        }
+        'C2': model.outputs[0],
+        'C3': model.outputs[1],
+        'C4': model.outputs[2],
+        'C5': model.outputs[3]
+    }
 
     model = retinanet.retinanet(inputs=inputs, num_classes=num_classes, backbone_layers=backbone_layers, **kwargs)
 

--- a/keras_retinanet/models/effnet.py
+++ b/keras_retinanet/models/effnet.py
@@ -119,10 +119,10 @@ def effnet_retinanet(num_classes, backbone='EfficientNetB0', inputs=None, modifi
 
     # C2 not provided
     backbone_layers = {
-        'C3' : model.outputs[0],
-        'C4' : model.outputs[1],
-        'C5' : model.outputs[2]
-        }
+        'C3': model.outputs[0],
+        'C4': model.outputs[1],
+        'C5': model.outputs[2]
+    }
 
     # create the full model
     return retinanet.retinanet(inputs=inputs, num_classes=num_classes, backbone_layers=backbone_layers, **kwargs)

--- a/keras_retinanet/models/effnet.py
+++ b/keras_retinanet/models/effnet.py
@@ -117,8 +117,15 @@ def effnet_retinanet(num_classes, backbone='EfficientNetB0', inputs=None, modifi
     if modifier:
         model = modifier(model)
 
+    # C2 not provided
+    backbone_layers = {
+        'C3' : model.outputs[0],
+        'C4' : model.outputs[1],
+        'C5' : model.outputs[2]
+        }
+
     # create the full model
-    return retinanet.retinanet(inputs=inputs, num_classes=num_classes, backbone_layers=model.outputs, **kwargs)
+    return retinanet.retinanet(inputs=inputs, num_classes=num_classes, backbone_layers=backbone_layers, **kwargs)
 
 
 def EfficientNetB0_retinanet(num_classes, inputs=None, **kwargs):

--- a/keras_retinanet/models/mobilenet.py
+++ b/keras_retinanet/models/mobilenet.py
@@ -108,9 +108,9 @@ def mobilenet_retinanet(num_classes, backbone='mobilenet224_1.0', inputs=None, m
 
     # C2 not provided
     backbone_layers = {
-        'C3' : backbone.outputs[0],
-        'C4' : backbone.outputs[1],
-        'C5' : backbone.outputs[2]
-        }
+        'C3': backbone.outputs[0],
+        'C4': backbone.outputs[1],
+        'C5': backbone.outputs[2]
+    }
 
     return retinanet.retinanet(inputs=inputs, num_classes=num_classes, backbone_layers=backbone_layers, **kwargs)

--- a/keras_retinanet/models/mobilenet.py
+++ b/keras_retinanet/models/mobilenet.py
@@ -106,4 +106,11 @@ def mobilenet_retinanet(num_classes, backbone='mobilenet224_1.0', inputs=None, m
     if modifier:
         backbone = modifier(backbone)
 
-    return retinanet.retinanet(inputs=inputs, num_classes=num_classes, backbone_layers=backbone.outputs, **kwargs)
+    # C2 not provided
+    backbone_layers = {
+        'C3' : backbone.outputs[0],
+        'C4' : backbone.outputs[1],
+        'C5' : backbone.outputs[2]
+        }
+
+    return retinanet.retinanet(inputs=inputs, num_classes=num_classes, backbone_layers=backbone_layers, **kwargs)

--- a/keras_retinanet/models/resnet.py
+++ b/keras_retinanet/models/resnet.py
@@ -109,7 +109,7 @@ def resnet_retinanet(num_classes, backbone='resnet50', inputs=None, modifier=Non
         resnet = modifier(resnet)
 
     # create the full model
-    return retinanet.retinanet(inputs=inputs, num_classes=num_classes, backbone_layers=resnet.outputs[1:], **kwargs)
+    return retinanet.retinanet(inputs=inputs, num_classes=num_classes, backbone_layers=resnet.outputs[:], **kwargs)
 
 
 def resnet50_retinanet(num_classes, inputs=None, **kwargs):

--- a/keras_retinanet/models/resnet.py
+++ b/keras_retinanet/models/resnet.py
@@ -110,7 +110,7 @@ def resnet_retinanet(num_classes, backbone='resnet50', inputs=None, modifier=Non
 
     # create the full model
     # resnet.outputs contains 4 layers
-    return retinanet.retinanet(inputs=inputs, num_classes=num_classes, backbone_layers=resnet.outputs[:], **kwargs)
+    return retinanet.retinanet(inputs=inputs, num_classes=num_classes, backbone_layers=resnet.outputs, **kwargs)
 
 
 def resnet50_retinanet(num_classes, inputs=None, **kwargs):

--- a/keras_retinanet/models/resnet.py
+++ b/keras_retinanet/models/resnet.py
@@ -109,6 +109,7 @@ def resnet_retinanet(num_classes, backbone='resnet50', inputs=None, modifier=Non
         resnet = modifier(resnet)
 
     # create the full model
+    # resnet.outputs contains 4 layers
     return retinanet.retinanet(inputs=inputs, num_classes=num_classes, backbone_layers=resnet.outputs[:], **kwargs)
 
 

--- a/keras_retinanet/models/resnet.py
+++ b/keras_retinanet/models/resnet.py
@@ -111,12 +111,12 @@ def resnet_retinanet(num_classes, backbone='resnet50', inputs=None, modifier=Non
     # create the full model
     # resnet.outputs contains 4 layers
     backbone_layers = {
-        'C2' : resnet.outputs[0],
-        'C3' : resnet.outputs[1],
-        'C4' : resnet.outputs[2],
-        'C5' : resnet.outputs[3]
-        }
-        
+        'C2': resnet.outputs[0],
+        'C3': resnet.outputs[1],
+        'C4': resnet.outputs[2],
+        'C5': resnet.outputs[3]
+    }
+
     return retinanet.retinanet(inputs=inputs, num_classes=num_classes, backbone_layers=backbone_layers, **kwargs)
 
 

--- a/keras_retinanet/models/resnet.py
+++ b/keras_retinanet/models/resnet.py
@@ -110,7 +110,14 @@ def resnet_retinanet(num_classes, backbone='resnet50', inputs=None, modifier=Non
 
     # create the full model
     # resnet.outputs contains 4 layers
-    return retinanet.retinanet(inputs=inputs, num_classes=num_classes, backbone_layers=resnet.outputs, **kwargs)
+    backbone_layers = {
+        'C2' : resnet.outputs[0],
+        'C3' : resnet.outputs[1],
+        'C4' : resnet.outputs[2],
+        'C5' : resnet.outputs[3]
+        }
+        
+    return retinanet.retinanet(inputs=inputs, num_classes=num_classes, backbone_layers=backbone_layers, **kwargs)
 
 
 def resnet50_retinanet(num_classes, inputs=None, **kwargs):

--- a/keras_retinanet/models/retinanet.py
+++ b/keras_retinanet/models/retinanet.py
@@ -368,6 +368,10 @@ def retinanet_bbox(
     if pyramid_levels is None:
         pyramid_levels = [3, 4, 5, 6, 7]
 
+    assert len(pyramid_levels) == len(anchor_params.sizes), \
+        "number of pyramid levels {} should match number of anchor parameter sizes {}".format(len(pyramid_levels),
+                                                                                              len(anchor_params.sizes))
+
     pyramid_layer_names = ['P{}'.format(p) for p in pyramid_levels]
     # compute the anchors
     features = [model.get_layer(p_name).output for p_name in pyramid_layer_names]

--- a/keras_retinanet/models/retinanet.py
+++ b/keras_retinanet/models/retinanet.py
@@ -315,10 +315,8 @@ def retinanet(
         raise ValueError('Must provide at least 3 layers for backbone')
 
     if backbone_layer_number < 4 and 2 in pyramid_levels:
-        raise ValueError("backbone model providing {} layers. Need 4 backbone layers to use pyramid level 2 layers.\
-         Only resnet returns 4 layers and will work with pyramid level 2 ".format(backbone_layer_number))
+        raise ValueError("backbone model providing {} layers. Need 4 backbone layers to use pyramid level 2 layers.".format(backbone_layer_number))
 
-    # Resent backbone has 4 usable layers. Other backbone models have 3.
     if backbone_layer_number >= 4:
         if 2 in pyramid_levels:
             C2 = backbone_layers[backbone_layer_counter]

--- a/keras_retinanet/models/retinanet.py
+++ b/keras_retinanet/models/retinanet.py
@@ -124,42 +124,65 @@ def default_regression_model(num_values, num_anchors, pyramid_feature_size=256, 
     return keras.models.Model(inputs=inputs, outputs=outputs, name=name)
 
 
-def __create_pyramid_features(C3, C4, C5, feature_size=256):
+def __create_pyramid_features(C3, C4, C5, pyramid_levels, C2=None, feature_size=256):
     """ Creates the FPN layers on top of the backbone features.
 
     Args
         C3           : Feature stage C3 from the backbone.
         C4           : Feature stage C4 from the backbone.
         C5           : Feature stage C5 from the backbone.
+        C2           : Feature stage C2 from the backbone (if pyramid level 2 is in use).
+        pyramid_levels: pyramid levels in use.
         feature_size : The feature size to use for the resulting feature levels.
 
     Returns
-        A list of feature levels [P3, P4, P5, P6, P7].
+        A list of feature levels. P3, P4, P5, P6 are always included. P2 and P7 included if in use.
     """
+
+    output_layers = {}
+
     # upsample C5 to get P5 from the FPN paper
     P5           = keras.layers.Conv2D(feature_size, kernel_size=1, strides=1, padding='same', name='C5_reduced')(C5)
     P5_upsampled = layers.UpsampleLike(name='P5_upsampled')([P5, C4])
     P5           = keras.layers.Conv2D(feature_size, kernel_size=3, strides=1, padding='same', name='P5')(P5)
+    output_layers["P5"] = P5
 
     # add P5 elementwise to C4
     P4           = keras.layers.Conv2D(feature_size, kernel_size=1, strides=1, padding='same', name='C4_reduced')(C4)
     P4           = keras.layers.Add(name='P4_merged')([P5_upsampled, P4])
     P4_upsampled = layers.UpsampleLike(name='P4_upsampled')([P4, C3])
     P4           = keras.layers.Conv2D(feature_size, kernel_size=3, strides=1, padding='same', name='P4')(P4)
+    output_layers["P4"] = P4
 
     # add P4 elementwise to C3
     P3 = keras.layers.Conv2D(feature_size, kernel_size=1, strides=1, padding='same', name='C3_reduced')(C3)
     P3 = keras.layers.Add(name='P3_merged')([P4_upsampled, P3])
+    if (C2 is not None) and (2 in pyramid_levels):
+        P3_upsampled = layers.UpsampleLike(name='P3_upsampled')([P3, C2])
     P3 = keras.layers.Conv2D(feature_size, kernel_size=3, strides=1, padding='same', name='P3')(P3)
+    output_layers["P3"] = P3
+
+    if (C2 is not None) and (2 in pyramid_levels):
+        P2 = keras.layers.Conv2D(feature_size, kernel_size=1, strides=1, padding='same', name='C2_reduced')(C2)
+        P2 = keras.layers.Add(name='P2_merged')([P3_upsampled, P2])
+        P2 = keras.layers.Conv2D(feature_size, kernel_size=3, strides=1, padding='same', name='P2')(P2)
+        output_layers["P2"] = P2
+
+
 
     # "P6 is obtained via a 3x3 stride-2 conv on C5"
     P6 = keras.layers.Conv2D(feature_size, kernel_size=3, strides=2, padding='same', name='P6')(C5)
+    output_layers["P6"] = P6
+
 
     # "P7 is computed by applying ReLU followed by a 3x3 stride-2 conv on P6"
-    P7 = keras.layers.Activation('relu', name='C6_relu')(P6)
-    P7 = keras.layers.Conv2D(feature_size, kernel_size=3, strides=2, padding='same', name='P7')(P7)
+    if 7 in pyramid_levels:
+        P7 = keras.layers.Activation('relu', name='C6_relu')(P6)
+        P7 = keras.layers.Conv2D(feature_size, kernel_size=3, strides=2, padding='same', name='P7')(P7)
+        output_layers["P7"] = P7
 
-    return [P3, P4, P5, P6, P7]
+    return [output_layers['P'+str(p)] for p in pyramid_levels]
+
 
 
 def default_submodels(num_classes, num_anchors):
@@ -241,6 +264,7 @@ def retinanet(
     num_classes,
     num_anchors             = None,
     create_pyramid_features = __create_pyramid_features,
+    pyramid_levels          = None,
     submodels               = None,
     name                    = 'retinanet'
 ):
@@ -252,7 +276,8 @@ def retinanet(
         inputs                  : keras.layers.Input (or list of) for the input to the model.
         num_classes             : Number of classes to classify.
         num_anchors             : Number of base anchors.
-        create_pyramid_features : Functor for creating pyramid features given the features C3, C4, C5 from the backbone.
+        create_pyramid_features : Functor for creating pyramid features given the features C3, C4, C5, and possibly C2 from the backbone.
+        pyramid_levels          : pyramid levels to use.
         submodels               : Submodels to run on each feature map (default is regression and classification submodels).
         name                    : Name of the model.
 
@@ -273,10 +298,43 @@ def retinanet(
     if submodels is None:
         submodels = default_submodels(num_classes, num_anchors)
 
-    C3, C4, C5 = backbone_layers
+    if pyramid_levels is None:
+        pyramid_levels = [3,4,5,6,7]
 
+
+    C2, C3, C4, C5 = None, None, None, None
+
+    backbone_layer_counter = 0
+    backbone_layer_number = len(backbone_layers)
+    if backbone_layer_number < 3:
+        raise ValueError('Must provide at least 3 layers for backbone')
+
+    if 2 in pyramid_levels:
+        if backbone_layer_number < 4:
+            raise ValueError('Error: backbone model providing fewer than 4 layers. Need 4 to use P2 pyramid layers. only resenet implemented for P2 layers')
+        else:
+            C2 = backbone_layers[backbone_layer_counter]
+            backbone_layer_counter+=1
+
+    if 3 in pyramid_levels:
+        C3 = backbone_layers[backbone_layer_counter]
+        backbone_layer_counter+=1
+    else:
+        raise ValueError("pyramid level 3 and C3 are necessary for code function")
+
+    if 4 in pyramid_levels:
+        C4 = backbone_layers[backbone_layer_counter]
+        backbone_layer_counter+=1
+    else:
+        raise ValueError("pyramid level 4 and C4 are necessary for code function")
+
+    if 5 in pyramid_levels:
+        C5 = backbone_layers[backbone_layer_counter]
+    else:
+        raise ValueError("pyramid level 5 and C5 are necessary for code function")
     # compute pyramid features as per https://arxiv.org/abs/1708.02002
-    features = create_pyramid_features(C3, C4, C5)
+
+    features = create_pyramid_features(C3, C4, C5, C2=C2, pyramid_levels=pyramid_levels)
 
     # for all pyramid levels, run available submodels
     pyramids = __build_pyramid(submodels, features)
@@ -290,6 +348,7 @@ def retinanet_bbox(
     class_specific_filter = True,
     name                  = 'retinanet-bbox',
     anchor_params         = None,
+    pyramid_levels        = None,
     nms_threshold         = 0.5,
     score_threshold       = 0.05,
     max_detections        = 300,
@@ -307,6 +366,7 @@ def retinanet_bbox(
         class_specific_filter : Whether to use class specific filtering or filter for the best scoring class only.
         name                  : Name of the model.
         anchor_params         : Struct containing anchor parameters. If None, default values are used.
+        pyramid_levels        : pyramid levels to use.
         nms_threshold         : Threshold for the IoU value to determine when a box should be suppressed.
         score_threshold       : Threshold used to prefilter the boxes with.
         max_detections        : Maximum number of detections to keep.
@@ -334,8 +394,12 @@ def retinanet_bbox(
     else:
         assert_training_model(model)
 
+    if pyramid_levels is None:
+        pyramid_levels = [3,4,5,6,7]
+
+    pyramid_layer_names = ['P'+str(p) for p in pyramid_levels]
     # compute the anchors
-    features = [model.get_layer(p_name).output for p_name in ['P3', 'P4', 'P5', 'P6', 'P7']]
+    features = [model.get_layer(p_name).output for p_name in pyramid_layer_names]
     anchors  = __build_anchors(anchor_params, features)
 
     # we expect the anchors, regression and classification values as first output

--- a/keras_retinanet/models/retinanet.py
+++ b/keras_retinanet/models/retinanet.py
@@ -132,11 +132,11 @@ def __create_pyramid_features(C3, C4, C5, pyramid_levels, C2=None, feature_size=
         C4           : Feature stage C4 from the backbone.
         C5           : Feature stage C5 from the backbone.
         C2           : Feature stage C2 from the backbone (if pyramid level 2 is in use).
-        pyramid_levels: pyramid levels in use.
+        pyramid_levels: Pyramid levels in use.
         feature_size : The feature size to use for the resulting feature levels.
 
     Returns
-        A list of feature levels. P3, P4, P5, P6 are always included. P2 and P7 included if in use.
+        A list of feature levels. P3, P4, P5, P6 are always included. P2, P6, P7 included if in use.
     """
 
     output_layers = {}
@@ -168,13 +168,10 @@ def __create_pyramid_features(C3, C4, C5, pyramid_levels, C2=None, feature_size=
         P2 = keras.layers.Conv2D(feature_size, kernel_size=3, strides=1, padding='same', name='P2')(P2)
         output_layers["P2"] = P2
 
-
-
     # "P6 is obtained via a 3x3 stride-2 conv on C5"
     if 6 in pyramid_levels:
         P6 = keras.layers.Conv2D(feature_size, kernel_size=3, strides=2, padding='same', name='P6')(C5)
         output_layers["P6"] = P6
-
 
     # "P7 is computed by applying ReLU followed by a 3x3 stride-2 conv on P6"
     if 7 in pyramid_levels:
@@ -184,7 +181,7 @@ def __create_pyramid_features(C3, C4, C5, pyramid_levels, C2=None, feature_size=
         P7 = keras.layers.Conv2D(feature_size, kernel_size=3, strides=2, padding='same', name='P7')(P7)
         output_layers["P7"] = P7
 
-    return [output_layers['P'+str(p)] for p in pyramid_levels]
+    return [output_layers['P{}'.format(p)] for p in pyramid_levels]
 
 
 
@@ -302,7 +299,7 @@ def retinanet(
         submodels = default_submodels(num_classes, num_anchors)
 
     if pyramid_levels is None:
-        pyramid_levels = [3,4,5,6,7]
+        pyramid_levels = [3, 4, 5, 6, 7]
 
 
     C2, C3, C4, C5 = None, None, None, None

--- a/keras_retinanet/models/senet.py
+++ b/keras_retinanet/models/senet.py
@@ -121,10 +121,10 @@ def senet_retinanet(num_classes, backbone='seresnext50', inputs=None, modifier=N
 
     # C2 not provided
     backbone_layers = {
-        'C3' : model.outputs[0],
-        'C4' : model.outputs[1],
-        'C5' : model.outputs[2]
-        }
+        'C3': model.outputs[0],
+        'C4': model.outputs[1],
+        'C5': model.outputs[2]
+    }
 
     # create the full model
     return retinanet.retinanet(inputs=inputs, num_classes=num_classes, backbone_layers=backbone_layers, **kwargs)

--- a/keras_retinanet/models/senet.py
+++ b/keras_retinanet/models/senet.py
@@ -119,8 +119,15 @@ def senet_retinanet(num_classes, backbone='seresnext50', inputs=None, modifier=N
     if modifier:
         model = modifier(model)
 
+    # C2 not provided
+    backbone_layers = {
+        'C3' : model.outputs[0],
+        'C4' : model.outputs[1],
+        'C5' : model.outputs[2]
+        }
+
     # create the full model
-    return retinanet.retinanet(inputs=inputs, num_classes=num_classes, backbone_layers=model.outputs, **kwargs)
+    return retinanet.retinanet(inputs=inputs, num_classes=num_classes, backbone_layers=backbone_layers, **kwargs)
 
 
 def seresnet18_retinanet(num_classes, inputs=None, **kwargs):

--- a/keras_retinanet/models/vgg.py
+++ b/keras_retinanet/models/vgg.py
@@ -96,4 +96,12 @@ def vgg_retinanet(num_classes, backbone='vgg16', inputs=None, modifier=None, **k
     # create the full model
     layer_names = ["block3_pool", "block4_pool", "block5_pool"]
     layer_outputs = [vgg.get_layer(name).output for name in layer_names]
-    return retinanet.retinanet(inputs=inputs, num_classes=num_classes, backbone_layers=layer_outputs, **kwargs)
+
+    # C2 not provided
+    backbone_layers = {
+        'C3' : layer_outputs[0],
+        'C4' : layer_outputs[1],
+        'C5' : layer_outputs[2]
+        }
+
+    return retinanet.retinanet(inputs=inputs, num_classes=num_classes, backbone_layers=backbone_layers, **kwargs)

--- a/keras_retinanet/models/vgg.py
+++ b/keras_retinanet/models/vgg.py
@@ -99,9 +99,9 @@ def vgg_retinanet(num_classes, backbone='vgg16', inputs=None, modifier=None, **k
 
     # C2 not provided
     backbone_layers = {
-        'C3' : layer_outputs[0],
-        'C4' : layer_outputs[1],
-        'C5' : layer_outputs[2]
-        }
+        'C3': layer_outputs[0],
+        'C4': layer_outputs[1],
+        'C5': layer_outputs[2]
+    }
 
     return retinanet.retinanet(inputs=inputs, num_classes=num_classes, backbone_layers=backbone_layers, **kwargs)

--- a/keras_retinanet/preprocessing/generator.py
+++ b/keras_retinanet/preprocessing/generator.py
@@ -25,7 +25,7 @@ from ..utils.anchors import (
     anchors_for_shape,
     guess_shapes
 )
-from ..utils.config import parse_anchor_parameters
+from ..utils.config import parse_anchor_parameters, parse_pyramid_levels
 from ..utils.image import (
     TransformParameters,
     adjust_transform_for_image,
@@ -313,9 +313,13 @@ class Generator(keras.utils.Sequence):
 
     def generate_anchors(self, image_shape):
         anchor_params = None
+        pyramid_levels = None
         if self.config and 'anchor_parameters' in self.config:
             anchor_params = parse_anchor_parameters(self.config)
-        return anchors_for_shape(image_shape, anchor_params=anchor_params, shapes_callback=self.compute_shapes)
+        if self.config and 'pyramid_levels' in self.config:
+            pyramid_levels = parse_pyramid_levels(self.config)
+
+        return anchors_for_shape(image_shape, anchor_params=anchor_params, pyramid_levels = pyramid_levels, shapes_callback=self.compute_shapes)
 
     def compute_targets(self, image_group, annotations_group):
         """ Compute target outputs for the network using images and their annotations.

--- a/keras_retinanet/preprocessing/generator.py
+++ b/keras_retinanet/preprocessing/generator.py
@@ -319,7 +319,7 @@ class Generator(keras.utils.Sequence):
         if self.config and 'pyramid_levels' in self.config:
             pyramid_levels = parse_pyramid_levels(self.config)
 
-        return anchors_for_shape(image_shape, anchor_params=anchor_params, pyramid_levels = pyramid_levels, shapes_callback=self.compute_shapes)
+        return anchors_for_shape(image_shape, anchor_params=anchor_params, pyramid_levels=pyramid_levels, shapes_callback=self.compute_shapes)
 
     def compute_targets(self, image_group, annotations_group):
         """ Compute target outputs for the network using images and their annotations.

--- a/keras_retinanet/utils/config.py
+++ b/keras_retinanet/utils/config.py
@@ -36,7 +36,7 @@ def read_config_file(config_path):
         "Malformed config file. These keys are not valid: {}".format(config_keys - default_keys)
 
     if 'pyramid_levels' in config:
-        assert('P' in config['pyramid_levels']), "pyramid levels specified by P key"
+        assert('levels' in config['pyramid_levels']), "pyramid levels specified by levels key"
 
     return config
 
@@ -52,6 +52,6 @@ def parse_anchor_parameters(config):
 
 
 def parse_pyramid_levels(config):
-    levels = list(map(int, config['pyramid_levels']['P'].split(' ')))
+    levels = list(map(int, config['pyramid_levels']['levels'].split(' ')))
 
     return levels

--- a/keras_retinanet/utils/config.py
+++ b/keras_retinanet/utils/config.py
@@ -46,6 +46,7 @@ def parse_anchor_parameters(config):
 
     return AnchorParameters(sizes, strides, ratios, scales)
 
+
 def parse_pyramid_levels(config):
     levels = list(map(int, config['pyramid_levels']['P'].split(' ')))
 

--- a/keras_retinanet/utils/config.py
+++ b/keras_retinanet/utils/config.py
@@ -45,3 +45,8 @@ def parse_anchor_parameters(config):
     strides = list(map(int, config['anchor_parameters']['strides'].split(' ')))
 
     return AnchorParameters(sizes, strides, ratios, scales)
+
+def parse_pyramid_levels(config):
+    levels   = list(map(int, config['pyramid_levels']['P'].split(' ')))
+
+    return levels

--- a/keras_retinanet/utils/config.py
+++ b/keras_retinanet/utils/config.py
@@ -35,6 +35,9 @@ def read_config_file(config_path):
     assert config_keys <= default_keys, \
         "Malformed config file. These keys are not valid: {}".format(config_keys - default_keys)
 
+    if 'pyramid_levels' in config:
+        assert('P' in config['pyramid_levels']), "pyramid levels specified by P key"
+
     return config
 
 
@@ -43,6 +46,7 @@ def parse_anchor_parameters(config):
     scales  = np.array(list(map(float, config['anchor_parameters']['scales'].split(' '))), keras.backend.floatx())
     sizes   = list(map(int, config['anchor_parameters']['sizes'].split(' ')))
     strides = list(map(int, config['anchor_parameters']['strides'].split(' ')))
+    assert (len(sizes) == len(strides)), "sizes and strides should have an equal number of values"
 
     return AnchorParameters(sizes, strides, ratios, scales)
 

--- a/keras_retinanet/utils/config.py
+++ b/keras_retinanet/utils/config.py
@@ -47,6 +47,6 @@ def parse_anchor_parameters(config):
     return AnchorParameters(sizes, strides, ratios, scales)
 
 def parse_pyramid_levels(config):
-    levels   = list(map(int, config['pyramid_levels']['P'].split(' ')))
+    levels = list(map(int, config['pyramid_levels']['P'].split(' ')))
 
     return levels


### PR DESCRIPTION
TLDR, This feature accomplishes the following:
- allows user to pass custom list of pyramid levels via config file
- these pyramid levels are then parsed in all appropriate places. 
- allows use of pyramid layer 2 (P2) for resnet backbone 
- one minor unrelated bug fix in `debug.py` ( made`--show-annotations` a separate flag from `--annotations`, which is already in use) 

This PR would allow a user to use a custom set of pyramid levels, controlled by the config.ini file in a manner similar to how anchor_parameters are controlled now. 

Our team has found that using a P2 pyramid layer enables us to utilize ultra-fine (e.g. 3 pixel by 3 pixel) bounding boxes that are otherwise out of reach with current configurable parameters. Some of the code used here was contributed by my team member Brad Nelson (https://github.com/bnelsj) in our private fork.  

I tried to stick to stylistic conventions wherever I could, and it looked like `utils/anchors.py` already had a framework for configuring the `pyramid_levels` list. I simply implemented this more fully in the bin scripts. Unfortunately, there was a fair amount of re-writing the `retinanet.py` definition and making it somewhat uglier.  

In order to make P2 work, I had to modify `resnet.py` so that it would return 4 output layers to use as backbone, while no other backbone type currently returns 4 output layers. Therefore, pyramid level 2 (P2) only works with resnet backbones as written. I tried to explain these changes with informative errors and comments. 

The primary use of this feature would be to add P2, although a user can also exclude P7 and P6 if they desired. I did not allow users to exclude C3, C4, and C5. 

Note that the length of `pyramid_levels` must be the same as the list of `sizes` and `strides` in anchor_parameters, although this is not explicitly enforced. 

