### PR TITLE
Ignore files, update requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
+keras_retinanet/utils/compute_overlap.c
 
 # Distribution / packaging
 .Python
@@ -21,3 +22,6 @@ __pycache__/
 .coverage.*
 coverage.xml
 *.cover
+
+# IDE files
+.idea/

--- a/keras_retinanet/bin/train.py
+++ b/keras_retinanet/bin/train.py
@@ -199,12 +199,13 @@ def create_callbacks(model, training_model, prediction_model, validation_generat
         min_lr     = 0
     ))
 
-    callbacks.append(keras.callbacks.EarlyStopping(
-        monitor    = 'mAP',
-        patience   = 5,
-        mode       = 'max',
-        min_delta  = 0.01
-    ))
+    if args.evaluation and validation_generator:
+        callbacks.append(keras.callbacks.EarlyStopping(
+            monitor    = 'mAP',
+            patience   = 5,
+            mode       = 'max',
+            min_delta  = 0.01
+        ))
 
     if args.tensorboard_dir:
         callbacks.append(tensorboard_callback)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cython
-keras-resnet==0.1.0
+keras-resnet>=0.1.0
 git+https://github.com/cocodataset/cocoapi.git#subdirectory=PythonAPI
 h5py
 keras

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setuptools.setup(
     maintainer_email = 'h.gaiser@fizyr.com',
     cmdclass         = {'build_ext': BuildExtension},
     packages         = setuptools.find_packages(),
-    install_requires = ['keras', 'keras-resnet==0.1.0', 'six', 'scipy', 'cython', 'Pillow', 'opencv-python', 'progressbar2'],
+    install_requires = ['keras', 'keras-resnet>=0.1.0', 'six', 'scipy', 'cython', 'Pillow', 'opencv-python', 'progressbar2'],
     entry_points     = {
         'console_scripts': [
             'retinanet-train=keras_retinanet.bin.train:main',

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,7 @@
 check-manifest
 image-classifiers
 efficientnet
+pycocotools
 # pytest
 pytest-xdist
 pytest-cov


### PR DESCRIPTION
keras-resnet v0.2.0 works good, so I've added >=0.1.0 for compatibility
Also, as my python installation was clean, I figured out that `pycocotools` library is required in tests, and I had not installed it, and it was not flagged as required in tests.