### PR TITLE
Enable earlystopping only if validation set is provided

### DIFF
--- a/keras_retinanet/bin/train.py
+++ b/keras_retinanet/bin/train.py
@@ -199,12 +199,13 @@ def create_callbacks(model, training_model, prediction_model, validation_generat
         min_lr     = 0
     ))
 
-    callbacks.append(keras.callbacks.EarlyStopping(
-        monitor    = 'mAP',
-        patience   = 5,
-        mode       = 'max',
-        min_delta  = 0.01
-    ))
+    if args.evaluation and validation_generator:
+        callbacks.append(keras.callbacks.EarlyStopping(
+            monitor    = 'mAP',
+            patience   = 5,
+            mode       = 'max',
+            min_delta  = 0.01
+        ))
 
     if args.tensorboard_dir:
         callbacks.append(tensorboard_callback)


### PR DESCRIPTION
Related issue: #1366
EarlyStopping class uses mAP by default, but mAP only is computet if evaluation dataset is provided. If one tries to train the model without any validation dataset, a warning appears:

`RuntimeWarning: Early stopping conditioned on metric mAP which is not available. Available metrics are: loss,regression_loss,classification_loss,lr (self.monitor, ','.join(list(logs.keys()))), RuntimeWarning`