### PR TITLE
added --no-resize to 'evaluate.py' file

### DIFF
--- a/keras_retinanet/bin/evaluate.py
+++ b/keras_retinanet/bin/evaluate.py
@@ -113,7 +113,7 @@ def parse_args(args):
     parser.add_argument('--max-detections',   help='Max Detections per image (defaults to 100).', default=100, type=int)
     parser.add_argument('--save-path',        help='Path for saving images with detections (doesn\'t work for COCO).')
     parser.add_argument('--image-min-side',   help='Rescale the image so the smallest side is min_side.', type=int, default=800)
-    parser.add_argument('--image-max-side',   help='Rescale the image if the largest side is larger than max_side.', type=int, default=1333)    
+    parser.add_argument('--image-max-side',   help='Rescale the image if the largest side is larger than max_side.', type=int, default=1333)
     parser.add_argument('--no-resize',        help='Don''t rescale the image.', action='store_true')
     parser.add_argument('--config',           help='Path to a configuration parameters .ini file (only used with --convert-model).')
 

--- a/keras_retinanet/bin/evaluate.py
+++ b/keras_retinanet/bin/evaluate.py
@@ -54,6 +54,7 @@ def create_generator(args, preprocess_image):
             image_max_side=args.image_max_side,
             config=args.config,
             shuffle_groups=False,
+            no_resize=args.no_resize,
             **common_args
         )
     elif args.dataset_type == 'pascal':
@@ -65,6 +66,7 @@ def create_generator(args, preprocess_image):
             image_max_side=args.image_max_side,
             config=args.config,
             shuffle_groups=False,
+            no_resize=args.no_resize,
             **common_args
         )
     elif args.dataset_type == 'csv':
@@ -75,6 +77,7 @@ def create_generator(args, preprocess_image):
             image_max_side=args.image_max_side,
             config=args.config,
             shuffle_groups=False,
+            no_resize=args.no_resize,
             **common_args
         )
     else:
@@ -110,7 +113,8 @@ def parse_args(args):
     parser.add_argument('--max-detections',   help='Max Detections per image (defaults to 100).', default=100, type=int)
     parser.add_argument('--save-path',        help='Path for saving images with detections (doesn\'t work for COCO).')
     parser.add_argument('--image-min-side',   help='Rescale the image so the smallest side is min_side.', type=int, default=800)
-    parser.add_argument('--image-max-side',   help='Rescale the image if the largest side is larger than max_side.', type=int, default=1333)
+    parser.add_argument('--image-max-side',   help='Rescale the image if the largest side is larger than max_side.', type=int, default=1333)    
+    parser.add_argument('--no-resize',        help='Don''t rescale the image.', action='store_true')
     parser.add_argument('--config',           help='Path to a configuration parameters .ini file (only used with --convert-model).')
 
     return parser.parse_args(args)


### PR DESCRIPTION
First of all thanks for making this repository publicly available.

This PR addresses issue https://github.com/fizyr/keras-retinanet/issues/1404 (--no-resize in evaluate.py file). I've added,

* the '--no-resize' parameter in the 'parse_args()' function of the 'evaluate.py' file
* the 'no_resize=args.no_resize' parameter to the 'CocoGenerator', 'PascalVocGenerator' and 'CSVGenerator' (all 3 inherit of the class 'Generator') in the 'create_generator()' function of the 'evaluate.py' file 
