### PR TITLE
Make retinanet tflite combatible

### DIFF
--- a/keras_retinanet/backend/tensorflow_backend.py
+++ b/keras_retinanet/backend/tensorflow_backend.py
@@ -37,6 +37,8 @@ def map_fn(*args, **kwargs):
     dtype = kwargs.pop("dtype")
     sig = [tensorflow.TensorSpec(shapes[i], dtype=t) for i, t in
            enumerate(dtype)]
+
+    # Try to use the new feature fn_output_signature in TF 2.3, use fallback if this is not available
     try:
         return tensorflow.map_fn(*args, **kwargs, fn_output_signature=sig)
     except TypeError:

--- a/keras_retinanet/backend/tensorflow_backend.py
+++ b/keras_retinanet/backend/tensorflow_backend.py
@@ -33,18 +33,19 @@ def map_fn(*args, **kwargs):
     """ See https://www.tensorflow.org/api_docs/python/tf/map_fn .
     """
 
-    shapes = kwargs.pop("shapes")
-    dtype = kwargs.pop("dtype")
-    sig = [tensorflow.TensorSpec(shapes[i], dtype=t) for i, t in
-           enumerate(dtype)]
+    if "shapes" in kwargs:
+        shapes = kwargs.pop("shapes")
+        dtype = kwargs.pop("dtype")
+        sig = [tensorflow.TensorSpec(shapes[i], dtype=t) for i, t in
+               enumerate(dtype)]
 
-    # Try to use the new feature fn_output_signature in TF 2.3, use fallback if this is not available
-    try:
-        return tensorflow.map_fn(*args, **kwargs, fn_output_signature=sig)
-    except TypeError:
-        pass
+        # Try to use the new feature fn_output_signature in TF 2.3, use fallback if this is not available
+        try:
+            return tensorflow.map_fn(*args, **kwargs, fn_output_signature=sig)
+        except TypeError:
+            kwargs["dtype"] = dtype
 
-    return tensorflow.map_fn(*args, **kwargs, dtype=dtype)
+    return tensorflow.map_fn(*args, **kwargs)
 
 
 def pad(*args, **kwargs):

--- a/keras_retinanet/backend/tensorflow_backend.py
+++ b/keras_retinanet/backend/tensorflow_backend.py
@@ -32,7 +32,17 @@ def transpose(*args, **kwargs):
 def map_fn(*args, **kwargs):
     """ See https://www.tensorflow.org/api_docs/python/tf/map_fn .
     """
-    return tensorflow.map_fn(*args, **kwargs)
+
+    shapes = kwargs.pop("shapes")
+    dtype = kwargs.pop("dtype")
+    sig = [tensorflow.TensorSpec(shapes[i], dtype=t) for i, t in
+           enumerate(dtype)]
+    try:
+        return tensorflow.map_fn(*args, **kwargs, fn_output_signature=sig)
+    except TypeError:
+        pass
+
+    return tensorflow.map_fn(*args, **kwargs, dtype=dtype)
 
 
 def pad(*args, **kwargs):

--- a/keras_retinanet/layers/filter_detections.py
+++ b/keras_retinanet/layers/filter_detections.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 import keras
 from .. import backend
+import  tensorflow
 
 
 def filter_detections(
@@ -172,11 +173,15 @@ class FilterDetections(keras.layers.Layer):
             )
 
         # call filter_detections on each batch
+        dtypes = [keras.backend.floatx(), keras.backend.floatx(), 'int32'] + [o.dtype for o in other]
+        shapes = [(self.max_detections,4), (self.max_detections,), (self.max_detections),]
+        shapes.extend([(self.max_detections,) + o.shape[2:] for o in other])
         outputs = backend.map_fn(
             _filter_detections,
             elems=[boxes, classification, other],
-            dtype=[keras.backend.floatx(), keras.backend.floatx(), 'int32'] + [o.dtype for o in other],
-            parallel_iterations=self.parallel_iterations
+            dtype=dtypes,
+            shapes=shapes,
+            parallel_iterations=self.parallel_iterations,
         )
 
         return outputs

--- a/keras_retinanet/layers/filter_detections.py
+++ b/keras_retinanet/layers/filter_detections.py
@@ -16,7 +16,6 @@ limitations under the License.
 
 import keras
 from .. import backend
-import  tensorflow
 
 
 def filter_detections(


### PR DESCRIPTION
This changes are necessary to convert a retinanet to tflite.
I think it is a nice to have.

However, the code is based on my PR for Keras 2.4