### PR TITLE
Reorder resize_image and preprocess_image calls for quicker computations

### DIFF
--- a/keras_retinanet/preprocessing/generator.py
+++ b/keras_retinanet/preprocessing/generator.py
@@ -54,6 +54,7 @@ class Generator(keras.utils.Sequence):
         compute_anchor_targets=anchor_targets_bbox,
         compute_shapes=guess_shapes,
         preprocess_image=preprocess_image,
+        resize_invariant_preprocessing=True,
         config=None
     ):
         """ Initialize Generator object.
@@ -71,19 +72,20 @@ class Generator(keras.utils.Sequence):
             compute_shapes         : Function handler for computing the shapes of the pyramid for a given input.
             preprocess_image       : Function handler for preprocessing an image (scaling / normalizing) for passing through a network.
         """
-        self.transform_generator    = transform_generator
-        self.visual_effect_generator = visual_effect_generator
-        self.batch_size             = int(batch_size)
-        self.group_method           = group_method
-        self.shuffle_groups         = shuffle_groups
-        self.image_min_side         = image_min_side
-        self.image_max_side         = image_max_side
-        self.no_resize              = no_resize
-        self.transform_parameters   = transform_parameters or TransformParameters()
-        self.compute_anchor_targets = compute_anchor_targets
-        self.compute_shapes         = compute_shapes
-        self.preprocess_image       = preprocess_image
-        self.config                 = config
+        self.transform_generator            = transform_generator
+        self.visual_effect_generator        = visual_effect_generator
+        self.batch_size                     = int(batch_size)
+        self.group_method                   = group_method
+        self.shuffle_groups                 = shuffle_groups
+        self.image_min_side                 = image_min_side
+        self.image_max_side                 = image_max_side
+        self.no_resize                      = no_resize
+        self.transform_parameters           = transform_parameters or TransformParameters()
+        self.compute_anchor_targets         = compute_anchor_targets
+        self.compute_shapes                 = compute_shapes
+        self.preprocess_image               = preprocess_image
+        self.resize_invariant_preprocessing = resize_invariant_preprocessing
+        self.config                         = config
 
         # Define groups
         self.group_images()
@@ -255,11 +257,20 @@ class Generator(keras.utils.Sequence):
     def preprocess_group_entry(self, image, annotations):
         """ Preprocess image and its annotations.
         """
-        # preprocess the image
-        image = self.preprocess_image(image)
+        if self.resize_invariant_preprocessing:
+            # this order is quicker
 
-        # resize image
-        image, image_scale = self.resize_image(image)
+            # resize image
+            image, image_scale = self.resize_image(image)
+
+            # preprocess the image
+            image = self.preprocess_image(image)
+        else:
+            # preprocess the image
+            image = self.preprocess_image(image)
+
+            # resize image
+            image, image_scale = self.resize_image(image)
 
         # apply resizing to annotations too
         annotations['bboxes'] *= image_scale

--- a/keras_retinanet/preprocessing/generator.py
+++ b/keras_retinanet/preprocessing/generator.py
@@ -54,7 +54,6 @@ class Generator(keras.utils.Sequence):
         compute_anchor_targets=anchor_targets_bbox,
         compute_shapes=guess_shapes,
         preprocess_image=preprocess_image,
-        resize_invariant_preprocessing=True,
         config=None
     ):
         """ Initialize Generator object.
@@ -84,7 +83,6 @@ class Generator(keras.utils.Sequence):
         self.compute_anchor_targets         = compute_anchor_targets
         self.compute_shapes                 = compute_shapes
         self.preprocess_image               = preprocess_image
-        self.resize_invariant_preprocessing = resize_invariant_preprocessing
         self.config                         = config
 
         # Define groups
@@ -257,20 +255,11 @@ class Generator(keras.utils.Sequence):
     def preprocess_group_entry(self, image, annotations):
         """ Preprocess image and its annotations.
         """
-        if self.resize_invariant_preprocessing:
-            # this order is quicker
+        # resize image
+        image, image_scale = self.resize_image(image)
 
-            # resize image
-            image, image_scale = self.resize_image(image)
-
-            # preprocess the image
-            image = self.preprocess_image(image)
-        else:
-            # preprocess the image
-            image = self.preprocess_image(image)
-
-            # resize image
-            image, image_scale = self.resize_image(image)
+        # preprocess the image
+        image = self.preprocess_image(image)
 
         # apply resizing to annotations too
         annotations['bboxes'] *= image_scale

--- a/keras_retinanet/utils/eval.py
+++ b/keras_retinanet/utils/eval.py
@@ -76,12 +76,8 @@ def _get_detections(generator, model, score_threshold=0.05, max_detections=100, 
 
     for i in progressbar.progressbar(range(generator.size()), prefix='Running network: '):
         raw_image    = generator.load_image(i)
-        if generator.resize_invariant_preprocessing:
-            image, scale = generator.resize_image(raw_image.copy())
-            image = generator.preprocess_image(image)
-        else:
-            image = generator.preprocess_image(raw_image.copy())
-            image, scale = generator.resize_image(image)
+        image, scale = generator.resize_image(raw_image.copy())
+        image = generator.preprocess_image(image)
 
         if keras.backend.image_data_format() == 'channels_first':
             image = image.transpose((2, 0, 1))

--- a/keras_retinanet/utils/eval.py
+++ b/keras_retinanet/utils/eval.py
@@ -76,8 +76,12 @@ def _get_detections(generator, model, score_threshold=0.05, max_detections=100, 
 
     for i in progressbar.progressbar(range(generator.size()), prefix='Running network: '):
         raw_image    = generator.load_image(i)
-        image        = generator.preprocess_image(raw_image.copy())
-        image, scale = generator.resize_image(image)
+        if generator.resize_invariant_preprocessing:
+            image = generator.preprocess_image(raw_image.copy())
+            image, scale = generator.resize_image(image)
+        else:
+            image = generator.preprocess_image(raw_image.copy())
+            image, scale = generator.resize_image(image)
 
         if keras.backend.image_data_format() == 'channels_first':
             image = image.transpose((2, 0, 1))

--- a/keras_retinanet/utils/eval.py
+++ b/keras_retinanet/utils/eval.py
@@ -77,8 +77,8 @@ def _get_detections(generator, model, score_threshold=0.05, max_detections=100, 
     for i in progressbar.progressbar(range(generator.size()), prefix='Running network: '):
         raw_image    = generator.load_image(i)
         if generator.resize_invariant_preprocessing:
-            image, scale = generator.resize_image(image)
-            image = generator.preprocess_image(raw_image.copy())
+            image, scale = generator.resize_image(raw_image.copy())
+            image = generator.preprocess_image(image)
         else:
             image = generator.preprocess_image(raw_image.copy())
             image, scale = generator.resize_image(image)

--- a/keras_retinanet/utils/eval.py
+++ b/keras_retinanet/utils/eval.py
@@ -77,8 +77,8 @@ def _get_detections(generator, model, score_threshold=0.05, max_detections=100, 
     for i in progressbar.progressbar(range(generator.size()), prefix='Running network: '):
         raw_image    = generator.load_image(i)
         if generator.resize_invariant_preprocessing:
-            image = generator.preprocess_image(raw_image.copy())
             image, scale = generator.resize_image(image)
+            image = generator.preprocess_image(raw_image.copy())
         else:
             image = generator.preprocess_image(raw_image.copy())
             image, scale = generator.resize_image(image)


### PR DESCRIPTION
Hello!

We were trying to optimize a pipeline that uses keras_retinanet in our project and found out that preliminary steps before image processing can take quite a while. We are working with images of size 4000x3000 and invoking `preprocess_image` turns out to be relatively expensive operation. However, it is immediatly followed by `resize_image` that makes the image noticeable smaller. Taking into account that `preprocess_image` in both `'caffe`' and `'tf'` modes uses constant numbers only, without any image-dependent  statistics, wouldn't it be better to swap the two functions' calls?

I've compared numerical results of the both call orders. To be honest, they are slightly different, but the difference is 1e-5 at maximum, though speed up increase is about x7:
 https://github.com/lacmus-foundation/lacmus-research/blob/master/resize_preprocess_order.ipynb