### PR TITLE
Add group-method arg for train

### DIFF
--- a/keras_retinanet/bin/debug.py
+++ b/keras_retinanet/bin/debug.py
@@ -56,6 +56,13 @@ def create_generator(args):
     Args:
         args: parseargs arguments object.
     """
+    common_args = {
+        'config'           : args.config,
+        'image_min_side'   : args.image_min_side,
+        'image_max_side'   : args.image_max_side,
+        'group_method'     : args.group_method
+    }
+
     # create random transform generator for augmenting training data
     transform_generator = random_transform_generator(
         min_rotation=-0.1,
@@ -86,9 +93,7 @@ def create_generator(args):
             args.coco_set,
             transform_generator=transform_generator,
             visual_effect_generator=visual_effect_generator,
-            image_min_side=args.image_min_side,
-            image_max_side=args.image_max_side,
-            config=args.config
+            **common_args
         )
     elif args.dataset_type == 'pascal':
         generator = PascalVocGenerator(
@@ -97,9 +102,7 @@ def create_generator(args):
             image_extension=args.image_extension,
             transform_generator=transform_generator,
             visual_effect_generator=visual_effect_generator,
-            image_min_side=args.image_min_side,
-            image_max_side=args.image_max_side,
-            config=args.config
+            **common_args
         )
     elif args.dataset_type == 'csv':
         generator = CSVGenerator(
@@ -107,9 +110,7 @@ def create_generator(args):
             args.classes,
             transform_generator=transform_generator,
             visual_effect_generator=visual_effect_generator,
-            image_min_side=args.image_min_side,
-            image_max_side=args.image_max_side,
-            config=args.config
+            **common_args
         )
     elif args.dataset_type == 'oid':
         generator = OpenImagesGenerator(
@@ -121,9 +122,7 @@ def create_generator(args):
             annotation_cache_dir=args.annotation_cache_dir,
             transform_generator=transform_generator,
             visual_effect_generator=visual_effect_generator,
-            image_min_side=args.image_min_side,
-            image_max_side=args.image_max_side,
-            config=args.config
+            **common_args
         )
     elif args.dataset_type == 'kitti':
         generator = KittiGenerator(
@@ -131,9 +130,7 @@ def create_generator(args):
             subset=args.subset,
             transform_generator=transform_generator,
             visual_effect_generator=visual_effect_generator,
-            image_min_side=args.image_min_side,
-            image_max_side=args.image_max_side,
-            config=args.config
+            **common_args
         )
     else:
         raise ValueError('Invalid data type received: {}'.format(args.dataset_type))
@@ -187,6 +184,7 @@ def parse_args(args):
     parser.add_argument('--no-gui', help='Do not open a GUI window. Save images to an output directory instead.', action='store_true')
     parser.add_argument('--output-dir', help='The output directory to save images to if --no-gui is specified.', default='.')
     parser.add_argument('--flatten-output', help='Flatten the folder structure of saved output images into a single folder.', action='store_true')
+    parser.add_argument('--group-method', help='Determines how images are grouped together', type=str, default='ratio', choices=['none', 'random', 'ratio'])
 
     return parser.parse_args(args)
 

--- a/keras_retinanet/bin/evaluate.py
+++ b/keras_retinanet/bin/evaluate.py
@@ -40,7 +40,12 @@ def create_generator(args, preprocess_image):
     """ Create generators for evaluation.
     """
     common_args = {
-        'preprocess_image': preprocess_image,
+        'config'           : args.config,
+        'image_min_side'   : args.image_min_side,
+        'image_max_side'   : args.image_max_side,
+        'no_resize'        : args.no_resize,
+        'preprocess_image' : preprocess_image,
+        'group_method'     : args.group_method
     }
 
     if args.dataset_type == 'coco':
@@ -50,11 +55,7 @@ def create_generator(args, preprocess_image):
         validation_generator = CocoGenerator(
             args.coco_path,
             'val2017',
-            image_min_side=args.image_min_side,
-            image_max_side=args.image_max_side,
-            config=args.config,
             shuffle_groups=False,
-            no_resize=args.no_resize,
             **common_args
         )
     elif args.dataset_type == 'pascal':
@@ -62,22 +63,14 @@ def create_generator(args, preprocess_image):
             args.pascal_path,
             'test',
             image_extension=args.image_extension,
-            image_min_side=args.image_min_side,
-            image_max_side=args.image_max_side,
-            config=args.config,
             shuffle_groups=False,
-            no_resize=args.no_resize,
             **common_args
         )
     elif args.dataset_type == 'csv':
         validation_generator = CSVGenerator(
             args.annotations,
             args.classes,
-            image_min_side=args.image_min_side,
-            image_max_side=args.image_max_side,
-            config=args.config,
             shuffle_groups=False,
-            no_resize=args.no_resize,
             **common_args
         )
     else:
@@ -116,6 +109,7 @@ def parse_args(args):
     parser.add_argument('--image-max-side',   help='Rescale the image if the largest side is larger than max_side.', type=int, default=1333)
     parser.add_argument('--no-resize',        help='Don''t rescale the image.', action='store_true')
     parser.add_argument('--config',           help='Path to a configuration parameters .ini file (only used with --convert-model).')
+    parser.add_argument('--group-method',     help='Determines how images are grouped together', type=str, default='ratio', choices=['none', 'random', 'ratio'])
 
     return parser.parse_args(args)
 

--- a/keras_retinanet/bin/train.py
+++ b/keras_retinanet/bin/train.py
@@ -230,6 +230,7 @@ def create_generators(args, preprocess_image):
         'image_max_side'   : args.image_max_side,
         'no_resize'        : args.no_resize,
         'preprocess_image' : preprocess_image,
+        'group_method'     : args.group_method
     }
 
     # create random transform generator for augmenting training data
@@ -444,6 +445,7 @@ def parse_args(args):
     parser.add_argument('--compute-val-loss', help='Compute validation loss during training', dest='compute_val_loss', action='store_true')
     parser.add_argument('--reduce-lr-patience', help='Reduce learning rate after validation loss decreases over reduce_lr_patience epochs', type=int, default=2)
     parser.add_argument('--reduce-lr-factor', help='When learning rate is reduced due to reduce_lr_patience, multiply by reduce_lr_factor', type=float, default=0.1)
+    parser.add_argument('--group-method',     help='Determines how images are grouped together', type=str, default='ratio', choices=['none', 'random', 'ratio'])
 
     # Fit generator arguments
     parser.add_argument('--multiprocessing',  help='Use multiprocessing in fit_generator.', action='store_true')


### PR DESCRIPTION
Added an argument `group-method` for `retinanet-train`.

Current default method is very slow when the dataset was large; it reads whole dataset in group_images method.