### PR TITLE
Update tensorboard writer for tf version >= 2.0.0

### DIFF
--- a/keras_retinanet/callbacks/coco.py
+++ b/keras_retinanet/callbacks/coco.py
@@ -16,7 +16,6 @@ limitations under the License.
 
 from tensorflow import keras
 from ..utils.coco_eval import evaluate_coco
-from ..utils.tf_version import check_tf_version
 
 
 class CocoEval(keras.callbacks.Callback):
@@ -59,9 +58,6 @@ class CocoEval(keras.callbacks.Callback):
 
             if self.tensorboard:
                 import tensorflow as tf
-                # make sure tensorflow is the minimum required version
-                check_tf_version()
-
                 writer = tf.summary.create_file_writer(self.tensorboard.log_dir)
                 with writer.as_default():
                     for index, result in enumerate(coco_eval_stats):

--- a/keras_retinanet/callbacks/coco.py
+++ b/keras_retinanet/callbacks/coco.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 from tensorflow import keras
 from ..utils.coco_eval import evaluate_coco
+from ..utils.tf_version import check_tf_version
 
 
 class CocoEval(keras.callbacks.Callback):
@@ -58,17 +59,11 @@ class CocoEval(keras.callbacks.Callback):
 
             if self.tensorboard:
                 import tensorflow as tf
-                if tf.version.VERSION < '2.0.0':
-                    if self.tensorboard.writer:
-                        summary = tf.Summary()
-                        for index, result in enumerate(coco_eval_stats):
-                            summary_value = summary.value.add()
-                            summary_value.simple_value = result
-                            summary_value.tag = '{}. {}'.format(index + 1, coco_tag[index])
-                            self.tensorboard.writer.add_summary(summary, epoch)
-                else:
-                    writer = tf.summary.create_file_writer(self.tensorboard.log_dir)
-                    with writer.as_default():
-                        for index, result in enumerate(coco_eval_stats):
-                            tf.summary.scalar('{}. {}'.format(index + 1, coco_tag[index]), result, step=epoch)
-                        writer.flush()
+                # make sure tensorflow is the minimum required version
+                check_tf_version()
+
+                writer = tf.summary.create_file_writer(self.tensorboard.log_dir)
+                with writer.as_default():
+                    for index, result in enumerate(coco_eval_stats):
+                        tf.summary.scalar('{}. {}'.format(index + 1, coco_tag[index]), result, step=epoch)
+                    writer.flush()

--- a/keras_retinanet/callbacks/coco.py
+++ b/keras_retinanet/callbacks/coco.py
@@ -58,10 +58,17 @@ class CocoEval(keras.callbacks.Callback):
 
             if self.tensorboard:
                 import tensorflow as tf
-                if tf.version.VERSION < '2.0.0' and self.tensorboard.writer:
-                    summary = tf.Summary()
-                    for index, result in enumerate(coco_eval_stats):
-                        summary_value = summary.value.add()
-                        summary_value.simple_value = result
-                        summary_value.tag = '{}. {}'.format(index + 1, coco_tag[index])
-                        self.tensorboard.writer.add_summary(summary, epoch)
+                if tf.version.VERSION < '2.0.0':
+                    if self.tensorboard.writer:
+                        summary = tf.Summary()
+                        for index, result in enumerate(coco_eval_stats):
+                            summary_value = summary.value.add()
+                            summary_value.simple_value = result
+                            summary_value.tag = '{}. {}'.format(index + 1, coco_tag[index])
+                            self.tensorboard.writer.add_summary(summary, epoch)
+                else:
+                    writer = tf.summary.create_file_writer(self.tensorboard.log_dir)
+                    with writer.as_default():
+                        for index, result in enumerate(coco_eval_stats):
+                            tf.summary.scalar('{}. {}'.format(index + 1, coco_tag[index]), result, step=epoch)
+                        writer.flush()

--- a/keras_retinanet/callbacks/eval.py
+++ b/keras_retinanet/callbacks/eval.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 from tensorflow import keras
 from ..utils.eval import evaluate
+from ..utils.tf_version import check_tf_version
 
 
 class Evaluate(keras.callbacks.Callback):
@@ -85,26 +86,16 @@ class Evaluate(keras.callbacks.Callback):
 
         if self.tensorboard:
             import tensorflow as tf
-            if tf.version.VERSION < '2.0.0':
-                if self.tensorboard.writer:
-                    summary = tf.Summary()
-                    summary_value = summary.value.add()
-                    summary_value.simple_value = self.mean_ap
-                    summary_value.tag = "mAP"
-                    if self.verbose == 1:
-                        for label, (average_precision, num_annotations) in average_precisions.items():
-                            summary_value = summary.value.add()
-                            summary_value.simple_value = average_precision
-                            summary_value.tag = "AP_" + self.generator.label_to_name(label)
-                    self.tensorboard.writer.add_summary(summary, epoch)
-            else:
-                writer = tf.summary.create_file_writer(self.tensorboard.log_dir)
-                with writer.as_default():
-                    tf.summary.scalar("mAP", self.mean_ap, step=epoch)
-                    if self.verbose == 1:
-                        for label, (average_precision, num_annotations) in average_precisions.items():
-                            tf.summary.scalar("AP_" + self.generator.label_to_name(label), average_precision, step=epoch)
-                    writer.flush()
+            # make sure tensorflow is the minimum required version
+            check_tf_version()
+           
+            writer = tf.summary.create_file_writer(self.tensorboard.log_dir)
+            with writer.as_default():
+                tf.summary.scalar("mAP", self.mean_ap, step=epoch)
+                if self.verbose == 1:
+                    for label, (average_precision, num_annotations) in average_precisions.items():
+                        tf.summary.scalar("AP_" + self.generator.label_to_name(label), average_precision, step=epoch)
+                writer.flush()
 
         logs['mAP'] = self.mean_ap
 

--- a/keras_retinanet/callbacks/eval.py
+++ b/keras_retinanet/callbacks/eval.py
@@ -85,17 +85,26 @@ class Evaluate(keras.callbacks.Callback):
 
         if self.tensorboard:
             import tensorflow as tf
-            if tf.version.VERSION < '2.0.0' and self.tensorboard.writer:
-                summary = tf.Summary()
-                summary_value = summary.value.add()
-                summary_value.simple_value = self.mean_ap
-                summary_value.tag = "mAP"
-                if self.verbose == 1:
-                    for label, (average_precision, num_annotations) in average_precisions.items():
-                        summary_value = summary.value.add()
-                        summary_value.simple_value = average_precision
-                        summary_value.tag = "AP_" + self.generator.label_to_name(label)
-                self.tensorboard.writer.add_summary(summary, epoch)
+            if tf.version.VERSION < '2.0.0':
+                if self.tensorboard.writer:
+                    summary = tf.Summary()
+                    summary_value = summary.value.add()
+                    summary_value.simple_value = self.mean_ap
+                    summary_value.tag = "mAP"
+                    if self.verbose == 1:
+                        for label, (average_precision, num_annotations) in average_precisions.items():
+                            summary_value = summary.value.add()
+                            summary_value.simple_value = average_precision
+                            summary_value.tag = "AP_" + self.generator.label_to_name(label)
+                    self.tensorboard.writer.add_summary(summary, epoch)
+            else:
+                writer = tf.summary.create_file_writer(self.tensorboard.log_dir)
+                with writer.as_default():
+                    tf.summary.scalar("mAP", self.mean_ap, step=epoch)
+                    if self.verbose == 1:
+                        for label, (average_precision, num_annotations) in average_precisions.items():
+                            tf.summary.scalar("AP_" + self.generator.label_to_name(label), average_precision, step=epoch)
+                    writer.flush()
 
         logs['mAP'] = self.mean_ap
 

--- a/keras_retinanet/callbacks/eval.py
+++ b/keras_retinanet/callbacks/eval.py
@@ -16,7 +16,6 @@ limitations under the License.
 
 from tensorflow import keras
 from ..utils.eval import evaluate
-from ..utils.tf_version import check_tf_version
 
 
 class Evaluate(keras.callbacks.Callback):
@@ -85,10 +84,7 @@ class Evaluate(keras.callbacks.Callback):
             self.mean_ap = sum(precisions) / sum(x > 0 for x in total_instances)
 
         if self.tensorboard:
-            import tensorflow as tf
-            # make sure tensorflow is the minimum required version
-            check_tf_version()
-           
+            import tensorflow as tf           
             writer = tf.summary.create_file_writer(self.tensorboard.log_dir)
             with writer.as_default():
                 tf.summary.scalar("mAP", self.mean_ap, step=epoch)


### PR DESCRIPTION
- updated writer for eval.py
- updated writer for coco.py

`log_dir` is accessed via `self.tensorboard.log_dir` which can be assigned via `--tensorboard-dir` 

However, the rest of the arguments (such as `--tensorboard-freq`) are ignored.