### PR TITLE
Adding support for KITTI evaluation

### DIFF
--- a/keras_retinanet/bin/evaluate.py
+++ b/keras_retinanet/bin/evaluate.py
@@ -28,6 +28,7 @@ if __name__ == "__main__" and __package__ is None:
 from .. import models
 from ..preprocessing.csv_generator import CSVGenerator
 from ..preprocessing.pascal_voc import PascalVocGenerator
+from ..preprocessing.kitti import KittiGenerator
 from ..utils.anchors import make_shapes_callback
 from ..utils.config import read_config_file, parse_anchor_parameters, parse_pyramid_levels
 from ..utils.eval import evaluate
@@ -72,6 +73,13 @@ def create_generator(args, preprocess_image):
             shuffle_groups=False,
             **common_args
         )
+    elif args.dataset_type == 'kitti':
+        validation_generator = KittiGenerator(
+            args.kitti_path,
+            'val',
+            shuffle_groups=False,
+            **common_args
+        )
     else:
         raise ValueError('Invalid data type received: {}'.format(args.dataset_type))
 
@@ -95,7 +103,10 @@ def parse_args(args):
     csv_parser = subparsers.add_parser('csv')
     csv_parser.add_argument('annotations', help='Path to CSV file containing annotations for evaluation.')
     csv_parser.add_argument('classes', help='Path to a CSV file containing class label mapping.')
-
+       
+    kitti_parser=subparsers.add_parser('kitti')
+    kitti_parser.add_argument('--kitti_path', help='Path to dataset directory')    
+    
     parser.add_argument('model',              help='Path to RetinaNet model.')
     parser.add_argument('--convert-model',    help='Convert the model to an inference model (ie. the input is a training model).', action='store_true')
     parser.add_argument('--backbone',         help='The backbone of the model.', default='resnet50')

--- a/keras_retinanet/bin/evaluate.py
+++ b/keras_retinanet/bin/evaluate.py
@@ -103,7 +103,7 @@ def parse_args(args):
     csv_parser = subparsers.add_parser('csv')
     csv_parser.add_argument('annotations', help='Path to CSV file containing annotations for evaluation.')
     csv_parser.add_argument('classes', help='Path to a CSV file containing class label mapping.')
-       
+    
     kitti_parser=subparsers.add_parser('kitti')
     kitti_parser.add_argument('--kitti_path', help='Path to dataset directory')    
     


### PR DESCRIPTION
evaluate.py wouldn't accept kitti as argument for evaluation even though the repository contains a script with the correct functionalities (../preprocessing/kitti.py). 

changes made: import kitti.py's correct function, definition of a new  kitti parser, added call to KittiGenerator() in create_generator().